### PR TITLE
Added variable to the error creation

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -45,7 +45,7 @@ func parseArgs(arg string) (args map[string]string, err error) {
 	re := regexp.MustCompile(" (\\w+)=(\\w+)")
 	pm := re.FindAllStringSubmatch(arg, -1)
 	if pm == nil {
-		return nil, fmt.Errorf("Failed to parse arg string: %q")
+		return nil, fmt.Errorf("Failed to parse arg string: %q", arg)
 	}
 
 	for _, m := range pm {


### PR DESCRIPTION
fmt.Errorf function didn't pass in the arg parameter provided. Based on the context of the log statement, I believe that is the value that should be logged. Great package! We are using it at work to send through Gmail's SMTP server.