### PR TITLE
Allow go-smtp to receive anonymous emails with no option to login

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ func (bkd *Backend) Login(username, password string) (smtp.User, error) {
 	return &User{}, nil
 }
 
+// Require clients to authenticate using SMTP AUTH before sending emails
+func (bkd *Backend) AnonymousLogin() (smtp.User, error) {
+	return nil, smtp.ErrAuthRequired
+}
+
 type User struct{}
 
 func (u *User) Send(from string, to []string, r io.Reader) error {

--- a/backend.go
+++ b/backend.go
@@ -8,6 +8,10 @@ import (
 type Backend interface {
 	// Authenticate a user.
 	Login(username, password string) (User, error)
+
+	// Called if the client attempts to send mail without logging in first.
+	// Respond with smtp.ErrAuthRequired if you don't want to support this.
+	AnonymousLogin() (User, error)
 }
 
 // An authenticated user.

--- a/server.go
+++ b/server.go
@@ -27,6 +27,10 @@ type Server struct {
 	AllowInsecureAuth bool
 	Debug             io.Writer
 
+	// If set, the AUTH command will not be advertised and authentication
+	// attempts will be rejected. This setting overrides AllowInsecureAuth.
+	AuthDisabled bool
+
 	// The server backend.
 	Backend Backend
 


### PR DESCRIPTION
This PR implements the ideas suggested in #8:

* Allow the `AUTH *` capabilities to be disabled completely
* Allow MUAs to send emails when not logged in

The combination of these two features is ideal when running one instance of go-smtp as an MTA on port 25 with both enabled, and another instance as an MSA on port 587 with both disabled.