### PR TITLE
Reset message after a successful send without logging authed user out

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -438,7 +438,7 @@ func (c *Conn) handleData(arg string) {
 		c.WriteResponse(code, msg)
 	}
 
-	c.reset()
+	c.resetMessage()
 }
 
 func (c *Conn) Reject() {
@@ -489,4 +489,11 @@ func (c *Conn) reset() {
 
 	c.user = nil
 	c.msg = nil
+}
+
+func (c *Conn) resetMessage() {
+	c.locker.Lock()
+	defer c.locker.Unlock()
+
+	c.msg = &message{}
 }


### PR DESCRIPTION
I've been using your library for an SMTP server and ran into an issue if a mail sender sends more than one mail in a single session, the reset() function removes the existing user and when the next MAIL FROM command comes in, it returns a 502 saying that the mail sender hasn't authenticated. I added a function to just reset the current message and changed handleData to call that rather than the full reset() function.