### PR TITLE
added missing import of "io" in server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ package main
 
 import (
 	"errors"
+	"io"
 	"io/ioutil"
 	"log"
 


### PR DESCRIPTION
The server example in `README.md` missed an import for `"io"`.