### PR TITLE
export SMTPError so it can be used in Send()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -411,7 +411,7 @@ func (c *Conn) handleData(arg string) {
 	err := c.User().Send(c.msg.From, c.msg.To, c.msg.Reader)
 	io.Copy(ioutil.Discard, c.msg.Reader) // Make sure all the data has been consumed
 	if err != nil {
-		if smtperr, ok := err.(*smtpError); ok {
+		if smtperr, ok := err.(*SMTPError); ok {
 			code = smtperr.Code
 			msg = smtperr.Message
 		} else {

--- a/data.go
+++ b/data.go
@@ -4,16 +4,17 @@ import (
 	"io"
 )
 
-type smtpError struct {
+// SMTPError specifies the error code and message that needs to be returned to the client
+type SMTPError struct {
 	Code    int
 	Message string
 }
 
-func (err *smtpError) Error() string {
+func (err *SMTPError) Error() string {
 	return err.Message
 }
 
-var ErrDataTooLarge = &smtpError{
+var ErrDataTooLarge = &SMTPError{
 	Code:    552,
 	Message: "Maximum message size exceeded",
 }


### PR DESCRIPTION
An exported smtpError struct makes it possible to have custom smtp errors codes in func Send. This is important for soft-failing (and retry later) errors.
```
func (u *User) Send(from string, to []string, r io.Reader) error {

[...]

	return &smtp.SMTPError{
		Code:    450
		Message: "Backend didn't repond, please retry later",
	}
}
```