### PR TITLE
Reintroduce updated backendutil.TransformBackend after 1a1363a

### DIFF
--- a/backendutil/backendutil.go
+++ b/backendutil/backendutil.go
@@ -1,0 +1,2 @@
+// Package backendutil provide utilities to implement SMTP backends.
+package backendutil

--- a/backendutil/transform.go
+++ b/backendutil/transform.go
@@ -10,8 +10,8 @@ import (
 type TransformBackend struct {
 	Backend smtp.Backend
 
-	Transform          func(username string) TransformHandler
-	AnonymousTransform func() TransformHandler
+	Transform          func(session *smtp.Session, username string) TransformHandler
+	AnonymousTransform func(session *smtp.Session) TransformHandler
 }
 
 // TransformHandler is a container for transforming funcs.
@@ -28,7 +28,7 @@ func (be *TransformBackend) Login(state *smtp.ConnectionState, username, passwor
 	if err != nil {
 		return nil, err
 	}
-	trans := be.Transform(username)
+	trans := be.Transform(&s, username)
 	return &transformSession{s, trans}, nil
 }
 
@@ -38,7 +38,7 @@ func (be *TransformBackend) AnonymousLogin(state *smtp.ConnectionState) (smtp.Se
 	if err != nil {
 		return nil, err
 	}
-	trans := be.AnonymousTransform()
+	trans := be.AnonymousTransform(&s)
 	return &transformSession{s, trans}, nil
 }
 

--- a/backendutil/transform.go
+++ b/backendutil/transform.go
@@ -1,0 +1,75 @@
+package backendutil
+
+import (
+	"io"
+
+	"github.com/emersion/go-smtp"
+)
+
+// TransformBackend is a backend that transforms messages.
+type TransformBackend struct {
+	Backend smtp.Backend
+
+	TransformReset func()
+	TransformMail  func(from string) (string, error)
+	TransformRcpt  func(to string) (string, error)
+	TransformData  func(r io.Reader) (io.Reader, error)
+}
+
+// Login implements the smtp.Backend interface.
+func (be *TransformBackend) Login(state *smtp.ConnectionState, username, password string) (smtp.Session, error) {
+	s, err := be.Backend.Login(state, username, password)
+	if err != nil {
+		return nil, err
+	}
+	return &transformSession{s, be}, nil
+}
+
+// AnonymousLogin implements the smtp.Backend interface.
+func (be *TransformBackend) AnonymousLogin(state *smtp.ConnectionState) (smtp.Session, error) {
+	s, err := be.Backend.AnonymousLogin(state)
+	if err != nil {
+		return nil, err
+	}
+	return &transformSession{s, be}, nil
+}
+
+type transformSession struct {
+	Session smtp.Session
+
+	be *TransformBackend
+}
+
+func (s *transformSession) Reset() {
+	s.be.TransformReset()
+	s.Session.Reset()
+}
+
+func (s *transformSession) Mail(from string) error {
+	from, err := s.be.TransformMail(from)
+	if err != nil {
+		return err
+	}
+	return s.Session.Mail(from)
+}
+
+func (s *transformSession) Rcpt(to string) error {
+	to, err := s.be.TransformRcpt(to)
+	if err != nil {
+		return err
+	}
+	return s.Session.Rcpt(to)
+}
+
+func (s *transformSession) Data(r io.Reader) error {
+	r, err := s.be.TransformData(r)
+	if err != nil {
+		return err
+	}
+	return s.Session.Data(r)
+}
+
+func (s *transformSession) Logout() error {
+	s.be.TransformReset()
+	return s.Session.Logout()
+}

--- a/backendutil/transform.go
+++ b/backendutil/transform.go
@@ -49,35 +49,48 @@ type transformSession struct {
 }
 
 func (s *transformSession) Reset() {
-	s.trans.TransformReset()
+	if s.trans != nil && s.trans.TransformReset != nil {
+		s.trans.TransformReset()
+	}
 	s.Session.Reset()
 }
 
 func (s *transformSession) Mail(from string) error {
-	from, err := s.trans.TransformMail(from)
-	if err != nil {
-		return err
+	if s.trans != nil && s.trans.TransformMail != nil {
+		var err error
+		from, err = s.trans.TransformMail(from)
+		if err != nil {
+			return err
+		}
 	}
 	return s.Session.Mail(from)
 }
 
 func (s *transformSession) Rcpt(to string) error {
-	to, err := s.trans.TransformRcpt(to)
-	if err != nil {
-		return err
+	if s.trans != nil && s.trans.TransformRcpt != nil {
+		var err error
+		to, err = s.trans.TransformRcpt(to)
+		if err != nil {
+			return err
+		}
 	}
 	return s.Session.Rcpt(to)
 }
 
 func (s *transformSession) Data(r io.Reader) error {
-	r, err := s.trans.TransformData(r)
-	if err != nil {
-		return err
+	if s.trans != nil && s.trans.TransformData != nil {
+		var err error
+		r, err = s.trans.TransformData(r)
+		if err != nil {
+			return err
+		}
 	}
 	return s.Session.Data(r)
 }
 
 func (s *transformSession) Logout() error {
-	s.trans.TransformReset()
+	if s.trans != nil && s.trans.TransformReset != nil {
+		s.trans.TransformReset()
+	}
 	return s.Session.Logout()
 }

--- a/backendutil/transform_test.go
+++ b/backendutil/transform_test.go
@@ -1,8 +1,323 @@
 package backendutil_test
 
 import (
+	"bufio"
+	"encoding/base64"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net"
+	"strings"
+	"testing"
+
 	"github.com/emersion/go-smtp"
 	"github.com/emersion/go-smtp/backendutil"
 )
 
 var _ smtp.Backend = &backendutil.TransformBackend{}
+
+type message struct {
+	From string
+	To   []string
+	Data []byte
+}
+
+type backend struct {
+	messages []*message
+	anonmsgs []*message
+
+	userErr error
+}
+
+func (be *backend) Login(_ *smtp.ConnectionState, username, password string) (smtp.Session, error) {
+	if be.userErr != nil {
+		return &session{}, be.userErr
+	}
+
+	if username != "username" || password != "password" {
+		return nil, errors.New("Invalid username or password")
+	}
+	return &session{backend: be}, nil
+}
+
+func (be *backend) AnonymousLogin(_ *smtp.ConnectionState) (smtp.Session, error) {
+	if be.userErr != nil {
+		return &session{}, be.userErr
+	}
+
+	return &session{backend: be, anonymous: true}, nil
+}
+
+type session struct {
+	backend   *backend
+	anonymous bool
+
+	msg *message
+}
+
+func (s *session) Reset() {
+	s.msg = &message{}
+}
+
+func (s *session) Logout() error {
+	return nil
+}
+
+func (s *session) Mail(from string) error {
+	s.Reset()
+	s.msg.From = from
+	return nil
+}
+
+func (s *session) Rcpt(to string) error {
+	s.msg.To = append(s.msg.To, to)
+	return nil
+}
+
+func (s *session) Data(r io.Reader) error {
+	if b, err := ioutil.ReadAll(r); err != nil {
+		return err
+	} else {
+		s.msg.Data = b
+		if s.anonymous {
+			s.backend.anonmsgs = append(s.backend.anonmsgs, s.msg)
+		} else {
+			s.backend.messages = append(s.backend.messages, s.msg)
+		}
+	}
+	return nil
+}
+
+type serverConfigureFunc func(*smtp.Server)
+
+func transformMailString(s string) (string, error) {
+	s = base64.StdEncoding.EncodeToString([]byte(s))
+	return s, nil
+}
+
+func transformMailReader(r io.Reader) (io.Reader, error) {
+	pr, pw := io.Pipe()
+	w := base64.NewEncoder(base64.StdEncoding, pw)
+	go copyAndClose(w, r, func(err error) { pw.CloseWithError(err) })
+	return pr, nil
+}
+
+func copyAndClose(w io.WriteCloser, r io.Reader, done func(err error)) {
+	_, err := io.Copy(w, r)
+	w.Close()
+	done(err)
+}
+
+func testServer(t *testing.T, fn ...serverConfigureFunc) (be *backend, s *smtp.Server, c net.Conn, scanner *bufio.Scanner) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	be = new(backend)
+	tbe := &backendutil.TransformBackend{
+		Backend:       be,
+		TransformMail: transformMailString,
+		TransformRcpt: transformMailString,
+		TransformData: transformMailReader,
+	}
+	s = smtp.NewServer(tbe)
+	s.Domain = "localhost"
+	s.AllowInsecureAuth = true
+	for _, f := range fn {
+		f(s)
+	}
+
+	go s.Serve(l)
+
+	c, err = net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scanner = bufio.NewScanner(c)
+	return
+}
+
+func testServerGreeted(t *testing.T, fn ...serverConfigureFunc) (be *backend, s *smtp.Server, c net.Conn, scanner *bufio.Scanner) {
+	be, s, c, scanner = testServer(t, fn...)
+
+	scanner.Scan()
+	if scanner.Text() != "220 localhost ESMTP Service Ready" {
+		t.Fatal("Invalid greeting:", scanner.Text())
+	}
+
+	return
+}
+
+func testServerEhlo(t *testing.T, fn ...serverConfigureFunc) (be *backend, s *smtp.Server, c net.Conn, scanner *bufio.Scanner, caps map[string]bool) {
+	be, s, c, scanner = testServerGreeted(t, fn...)
+
+	io.WriteString(c, "EHLO localhost\r\n")
+
+	scanner.Scan()
+	if scanner.Text() != "250-Hello localhost" {
+		t.Fatal("Invalid EHLO response:", scanner.Text())
+	}
+
+	expectedCaps := []string{"PIPELINING", "8BITMIME"}
+	caps = make(map[string]bool)
+
+	for scanner.Scan() {
+		s := scanner.Text()
+
+		if strings.HasPrefix(s, "250 ") {
+			caps[strings.TrimPrefix(s, "250 ")] = true
+			break
+		} else {
+			if !strings.HasPrefix(s, "250-") {
+				t.Fatal("Invalid capability response:", s)
+			}
+			caps[strings.TrimPrefix(s, "250-")] = true
+		}
+	}
+
+	for _, cap := range expectedCaps {
+		if !caps[cap] {
+			t.Fatal("Missing capability:", cap)
+		}
+	}
+
+	return
+}
+
+func testServerAuthenticated(t *testing.T) (be *backend, s *smtp.Server, c net.Conn, scanner *bufio.Scanner) {
+	be, s, c, scanner, caps := testServerEhlo(t)
+
+	if _, ok := caps["AUTH PLAIN"]; !ok {
+		t.Fatal("AUTH PLAIN capability is missing when auth is enabled")
+	}
+
+	io.WriteString(c, "AUTH PLAIN\r\n")
+	scanner.Scan()
+	if scanner.Text() != "334 " {
+		t.Fatal("Invalid AUTH response:", scanner.Text())
+	}
+
+	io.WriteString(c, "AHVzZXJuYW1lAHBhc3N3b3Jk\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "235 ") {
+		t.Fatal("Invalid AUTH response:", scanner.Text())
+	}
+
+	return
+}
+
+func TestServer(t *testing.T) {
+	be, s, c, scanner := testServerAuthenticated(t)
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "MAIL FROM:<root@nsa.gov>\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "250 ") {
+		t.Fatal("Invalid MAIL response:", scanner.Text())
+	}
+
+	io.WriteString(c, "RCPT TO:<root@gchq.gov.uk>\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "250 ") {
+		t.Fatal("Invalid RCPT response:", scanner.Text())
+	}
+
+	io.WriteString(c, "DATA\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "354 ") {
+		t.Fatal("Invalid DATA response:", scanner.Text())
+	}
+
+	io.WriteString(c, "Hey <3\r\n")
+	io.WriteString(c, ".\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "250 ") {
+		t.Fatal("Invalid DATA response:", scanner.Text())
+	}
+
+	if len(be.messages) != 1 || len(be.anonmsgs) != 0 {
+		t.Fatal("Invalid number of sent messages:", be.messages, be.anonmsgs)
+	}
+
+	msg := be.messages[0]
+	// base64 of "root@nsa.gov"
+	if msg.From != "cm9vdEBuc2EuZ292" {
+		t.Fatal("Invalid mail sender:", msg.From)
+	}
+	// base64 of "root@gchq.gov.uk"
+	if len(msg.To) != 1 || msg.To[0] != "cm9vdEBnY2hxLmdvdi51aw==" {
+		t.Fatal("Invalid mail recipients:", msg.To)
+	}
+	// base64 of "Hey <3\n" (with actual newline)
+	if string(msg.Data) != "SGV5IDwzCg==" {
+		t.Fatal("Invalid mail data:", string(msg.Data))
+	}
+}
+
+func TestServer_tooLongMessage(t *testing.T) {
+	be, s, c, scanner := testServerAuthenticated(t)
+	defer s.Close()
+
+	s.MaxMessageBytes = 50
+
+	io.WriteString(c, "MAIL FROM:<root@nsa.gov>\r\n")
+	scanner.Scan()
+	io.WriteString(c, "RCPT TO:<root@gchq.gov.uk>\r\n")
+	scanner.Scan()
+	io.WriteString(c, "DATA\r\n")
+	scanner.Scan()
+
+	io.WriteString(c, "This is a very long message.\r\n")
+	io.WriteString(c, "Much longer than you can possibly imagine.\r\n")
+	io.WriteString(c, "And much longer than the server's MaxMessageBytes.\r\n")
+	io.WriteString(c, ".\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "552 ") {
+		t.Fatal("Invalid DATA response, expected an error but got:", scanner.Text())
+	}
+
+	if len(be.messages) != 0 || len(be.anonmsgs) != 0 {
+		t.Fatal("Invalid number of sent messages:", be.messages, be.anonmsgs)
+	}
+}
+
+func TestServer_anonymousUserOK(t *testing.T) {
+	be, s, c, scanner, _ := testServerEhlo(t)
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "MAIL FROM: root@nsa.gov\r\n")
+	scanner.Scan()
+	io.WriteString(c, "RCPT TO:<root@gchq.gov.uk>\r\n")
+	scanner.Scan()
+	io.WriteString(c, "DATA\r\n")
+	scanner.Scan()
+	io.WriteString(c, "Hey <3\r\n")
+	io.WriteString(c, ".\r\n")
+	scanner.Scan()
+
+	if !strings.HasPrefix(scanner.Text(), "250 ") {
+		t.Fatal("Invalid DATA response:", scanner.Text())
+	}
+
+	if len(be.messages) != 0 || len(be.anonmsgs) != 1 {
+		t.Fatal("Invalid number of sent messages:", be.messages, be.anonmsgs)
+	}
+
+	msg := be.anonmsgs[0]
+	// base64 of "root@nsa.gov"
+	if msg.From != "cm9vdEBuc2EuZ292" {
+		t.Fatal("Invalid mail sender:", msg.From)
+	}
+	// base64 of "root@gchq.gov.uk"
+	if len(msg.To) != 1 || msg.To[0] != "cm9vdEBnY2hxLmdvdi51aw==" {
+		t.Fatal("Invalid mail recipients:", msg.To)
+	}
+	// base64 of "Hey <3\n" (with actual newline)
+	if string(msg.Data) != "SGV5IDwzCg==" {
+		t.Fatal("Invalid mail data:", string(msg.Data))
+	}
+}

--- a/backendutil/transform_test.go
+++ b/backendutil/transform_test.go
@@ -1,0 +1,8 @@
+package backendutil_test
+
+import (
+	"github.com/emersion/go-smtp"
+	"github.com/emersion/go-smtp/backendutil"
+)
+
+var _ smtp.Backend = &backendutil.TransformBackend{}

--- a/server_test.go
+++ b/server_test.go
@@ -405,7 +405,7 @@ func TestServer_tooManyInvalidCommands(t *testing.T) {
 }
 
 func TestServer_tooLongMessage(t *testing.T) {
-	_, s, c, scanner := testServerAuthenticated(t)
+	be, s, c, scanner := testServerAuthenticated(t)
 	defer s.Close()
 
 	s.MaxMessageBytes = 50
@@ -424,6 +424,10 @@ func TestServer_tooLongMessage(t *testing.T) {
 	scanner.Scan()
 	if !strings.HasPrefix(scanner.Text(), "552 ") {
 		t.Fatal("Invalid DATA response, expected an error but got:", scanner.Text())
+	}
+
+	if len(be.messages) != 0 || len(be.anonmsgs) != 0 {
+		t.Fatal("Invalid number of sent messages:", be.messages, be.anonmsgs)
 	}
 }
 


### PR DESCRIPTION
After considering the comments in https://github.com/emersion/go-smtp/issues/22 I still think that a TransformBackend could be useful. Especially for me since it is required for my little program https://github.com/mback2k/smtp-dkim-signer.

Considering the comments in https://github.com/emersion/go-smtp/issues/22#issuecomment-475669004 I think that option 2) "Split Transform function into separate TransformFrom, TransformTo, TransformData. Pass transformed data to underlying backend instantly." makes totally sense. The mentioned aspects are:
- The underlying backend does have an ability to report errors on From/Rcpt => true
- Can't use From/To information in TransformData =>  still possible since the required state can be kept with a Session-based approach

Therefore I am proposing to bring back TransformBackend with a Session-based approach of individual Transform functions that could be bound to an object themselves. I will post an example in a separate comment. What do you think?