### PR TITLE
Fix typo in example

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -114,7 +114,7 @@ func (s *Session) Mail(from string) error {
 }
 
 func (s *Session) Rcpt(to string) error {
-	log.Println("Rcpt to:", from)
+	log.Println("Rcpt to:", to)
 	return nil
 }
 


### PR DESCRIPTION
Typo in example file used 'from' rather than the argument 'to'