### PR TITLE
do not abort mailfrom if FROM is <> 

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -263,11 +263,12 @@ func (c *Conn) handleMail(arg string) {
 			return
 		}
 	}
-	from := strings.Trim(fromArgs[0], "<> ")
+	from := fromArgs[0]
 	if from == "" {
 		c.WriteResponse(501, EnhancedCode{5, 5, 2}, "Was expecting MAIL arg syntax of FROM:<address>")
 		return
 	}
+	from = strings.Trim(from, "<>")
 
 	// This is where the Conn may put BODY=8BITMIME, but we already
 	// read the DATA as bytes, so it does not effect our processing.

--- a/server_test.go
+++ b/server_test.go
@@ -224,7 +224,7 @@ func TestServerEmptyFrom2(t *testing.T) {
 
 	io.WriteString(c, "MAIL FROM:<>\r\n")
 	scanner.Scan()
-	if strings.HasPrefix(scanner.Text(), "250 ") {
+	if !strings.HasPrefix(scanner.Text(), "250 ") {
 		t.Fatal("Invalid MAIL response:", scanner.Text())
 	}
 


### PR DESCRIPTION
The change was rebased with changes from #55

A FROM Adress <> is valid and used for NDR Reports / MailerDaemon mails.