### PR TITLE
server: Restrict line length to 2000 bytes

### DIFF
--- a/lengthlimit_reader.go
+++ b/lengthlimit_reader.go
@@ -1,0 +1,47 @@
+package smtp
+
+import (
+	"errors"
+	"io"
+)
+
+var ErrTooLongLine = errors.New("smtp: too longer line in input stream")
+
+// lineLimitReader reads from the underlying Reader but restricts
+// line length of lines in input stream to a certain length.
+//
+// If line length exceeds the limit - Read returns ErrTooLongLine
+type lineLimitReader struct {
+	R         io.Reader
+	LineLimit int
+
+	curLineLength int
+}
+
+func (r lineLimitReader) Read(b []byte) (int, error) {
+	if r.curLineLength > r.LineLimit {
+		return 0, ErrTooLongLine
+	}
+
+	n, err := r.R.Read(b)
+	if err != nil {
+		return n, err
+	}
+
+	if r.LineLimit == 0 {
+		return n, nil
+	}
+
+	for _, chr := range b[:n] {
+		if chr == '\n' {
+			r.curLineLength = 0
+		}
+		r.curLineLength++
+
+		if r.curLineLength > r.LineLimit {
+			return 0, ErrTooLongLine
+		}
+	}
+
+	return n, nil
+}

--- a/server_test.go
+++ b/server_test.go
@@ -454,6 +454,17 @@ func TestServer_tooLongMessage(t *testing.T) {
 	}
 }
 
+func TestServer_tooLongLine(t *testing.T) {
+	_, s, c, scanner := testServerAuthenticated(t)
+	defer s.Close()
+
+	io.WriteString(c, "MAIL FROM:<root@nsa.gov> "+strings.Repeat("A", 2000))
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "500 ") {
+		t.Fatal("Invalid response, expected an error but got:", scanner.Text())
+	}
+}
+
 func TestServer_anonymousUserError(t *testing.T) {
 	be, s, c, scanner, _ := testServerEhlo(t)
 	defer s.Close()


### PR DESCRIPTION
Without this restriction, it is pretty easy to cause OOM condition on the server by sending infinite stream of characters without line breaks. See foxcpp/maddy#116.