### PR TITLE
Add Temporary method to SMTPError

### DIFF
--- a/data.go
+++ b/data.go
@@ -30,6 +30,10 @@ func (err *SMTPError) Error() string {
 	return err.Message
 }
 
+func (err *SMTPError) Temporary() bool {
+	return err.Code/100 == 4
+}
+
 var ErrDataTooLarge = &SMTPError{
 	Code:         552,
 	EnhancedCode: EnhancedCode{5, 3, 4},


### PR DESCRIPTION
This seems to be a convention[1] for errors that can be temporary and I find it convenient to be able to type-assert on `interface{Temporary() bool}` for any error to see if it is temporary or not.

[1]: Or at least it is implemented consistently by the net package.