### PR TITLE
Better support for optional MAIL Arguments

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -21,6 +21,13 @@ type Backend interface {
 	AnonymousLogin(state *ConnectionState) (Session, error)
 }
 
+// MailOptions contains custom arguments that were
+// passed as an argument to the MAIL command.
+type MailOptions struct {
+	// Size of the body. Can be 0 if not specified by client.
+	Size int
+}
+
 type Session interface {
 	// Discard currently processed message.
 	Reset()
@@ -29,7 +36,7 @@ type Session interface {
 	Logout() error
 
 	// Set return path for currently processed message.
-	Mail(from string) error
+	Mail(from string, opts MailOptions) error
 	// Add recipient for currently processed message.
 	Rcpt(to string) error
 	// Set currently processed message contents and send it.

--- a/backend.go
+++ b/backend.go
@@ -26,6 +26,10 @@ type Backend interface {
 type MailOptions struct {
 	// Size of the body. Can be 0 if not specified by client.
 	Size int
+
+	// The message envelope or message header contains UTF-8-encoded strings.
+	// This flag is set by SMTPUTF8-aware (RFC 6531) client.
+	UTF8 bool
 }
 
 type Session interface {

--- a/backend.go
+++ b/backend.go
@@ -27,6 +27,12 @@ type MailOptions struct {
 	// Size of the body. Can be 0 if not specified by client.
 	Size int
 
+	// TLS is required for the message transmission.
+	//
+	// The message should be rejected if it can't be transmitted
+	// with TLS.
+	RequireTLS bool
+
 	// The message envelope or message header contains UTF-8-encoded strings.
 	// This flag is set by SMTPUTF8-aware (RFC 6531) client.
 	UTF8 bool

--- a/backendutil/transform.go
+++ b/backendutil/transform.go
@@ -43,7 +43,7 @@ func (s *transformSession) Reset() {
 	s.Session.Reset()
 }
 
-func (s *transformSession) Mail(from string) error {
+func (s *transformSession) Mail(from string, opts smtp.MailOptions) error {
 	if s.be.TransformMail != nil {
 		var err error
 		from, err = s.be.TransformMail(from)
@@ -51,7 +51,7 @@ func (s *transformSession) Mail(from string) error {
 			return err
 		}
 	}
-	return s.Session.Mail(from)
+	return s.Session.Mail(from, opts)
 }
 
 func (s *transformSession) Rcpt(to string) error {

--- a/backendutil/transform_test.go
+++ b/backendutil/transform_test.go
@@ -63,7 +63,7 @@ func (s *session) Logout() error {
 	return nil
 }
 
-func (s *session) Mail(from string) error {
+func (s *session) Mail(from string, opts smtp.MailOptions) error {
 	s.Reset()
 	s.msg.From = from
 	return nil

--- a/client.go
+++ b/client.go
@@ -327,6 +327,13 @@ func (c *Client) MailExt(from string, opts MailOptions) error {
 	if _, ok := c.ext["SIZE"]; ok && opts.Size != 0 {
 		cmdStr += " SIZE=" + strconv.Itoa(opts.Size)
 	}
+	if opts.RequireTLS {
+		if _, ok := c.ext["REQUIRETLS"]; ok {
+			cmdStr += " REQUIRETLS"
+		} else {
+			return errors.New("smtp: server does not support REQUIRETLS")
+		}
+	}
 	if opts.UTF8 {
 		if _, ok := c.ext["SMTPUTF8"]; ok {
 			cmdStr += " SMTPUTF8"

--- a/client_test.go
+++ b/client_test.go
@@ -99,7 +99,7 @@ func TestBasic(t *testing.T) {
 		t.Fatalf("Shouldn't support DSN")
 	}
 
-	if err := c.Mail("user@gmail.com"); err == nil {
+	if err := c.Mail("user@gmail.com", nil); err == nil {
 		t.Fatalf("MAIL should require authentication")
 	}
 
@@ -123,10 +123,10 @@ func TestBasic(t *testing.T) {
 	if err := c.Rcpt("golang-nuts@googlegroups.com>\r\nDATA\r\nInjected message body\r\n.\r\nQUIT\r\n"); err == nil {
 		t.Fatalf("RCPT should have failed due to a message injection attempt")
 	}
-	if err := c.Mail("user@gmail.com>\r\nDATA\r\nAnother injected message body\r\n.\r\nQUIT\r\n"); err == nil {
+	if err := c.Mail("user@gmail.com>\r\nDATA\r\nAnother injected message body\r\n.\r\nQUIT\r\n", nil); err == nil {
 		t.Fatalf("MAIL should have failed due to a message injection attempt")
 	}
-	if err := c.Mail("user@gmail.com"); err != nil {
+	if err := c.Mail("user@gmail.com", nil); err != nil {
 		t.Fatalf("MAIL failed: %s", err)
 	}
 	if err := c.Rcpt("golang-nuts@googlegroups.com"); err != nil {
@@ -187,7 +187,7 @@ func TestBasic_SMTPError(t *testing.T) {
 		t.Fatalf("NewClient failed: %v", err)
 	}
 
-	err = c.Mail("whatever")
+	err = c.Mail("whatever", nil)
 	if err == nil {
 		t.Fatal("MAIL succeded")
 	}
@@ -205,7 +205,7 @@ func TestBasic_SMTPError(t *testing.T) {
 		t.Fatalf("Wrong message, got %s, want %s", smtpErr.Message, "Failing with enhanced code")
 	}
 
-	err = c.Mail("whatever")
+	err = c.Mail("whatever", nil)
 	if err == nil {
 		t.Fatal("MAIL succeded")
 	}
@@ -385,7 +385,7 @@ func TestHello(t *testing.T) {
 			c.serverName = "smtp.google.com"
 			err = c.Auth(sasl.NewPlainClient("", "user", "pass"))
 		case 4:
-			err = c.Mail("test@example.com")
+			err = c.Mail("test@example.com", nil)
 		case 5:
 			ok, _ := c.Extension("feature")
 			if ok {
@@ -851,7 +851,7 @@ func TestLMTP(t *testing.T) {
 	}
 	c.didHello = true
 
-	if err := c.Mail("user@gmail.com"); err != nil {
+	if err := c.Mail("user@gmail.com", nil); err != nil {
 		t.Fatalf("MAIL failed: %s", err)
 	}
 	if err := c.Rcpt("golang-nuts@googlegroups.com"); err != nil {

--- a/conn.go
+++ b/conn.go
@@ -284,6 +284,8 @@ func (c *Conn) handleMail(arg string) {
 	}
 	from = strings.Trim(from, "<>")
 
+	opts := MailOptions{}
+
 	// This is where the Conn may put BODY=8BITMIME, but we already
 	// read the DATA as bytes, so it does not effect our processing.
 	if len(fromArgs) > 1 {
@@ -304,10 +306,12 @@ func (c *Conn) handleMail(arg string) {
 				c.WriteResponse(552, EnhancedCode{5, 3, 4}, "Max message size exceeded")
 				return
 			}
+
+			opts.Size = int(size)
 		}
 	}
 
-	if err := c.Session().Mail(from); err != nil {
+	if err := c.Session().Mail(from, opts); err != nil {
 		if smtpErr, ok := err.(*SMTPError); ok {
 			c.WriteResponse(smtpErr.Code, smtpErr.EnhancedCode, smtpErr.Message)
 			return

--- a/conn.go
+++ b/conn.go
@@ -237,6 +237,9 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 		if c.server.EnableSMTPUTF8 {
 			caps = append(caps, "SMTPUTF8")
 		}
+		if _, isTLS := c.TLSConnectionState(); isTLS && c.server.EnableREQUIRETLS {
+			caps = append(caps, "REQUIRETLS")
+		}
 		if c.server.MaxMessageBytes > 0 {
 			caps = append(caps, fmt.Sprintf("SIZE %v", c.server.MaxMessageBytes))
 		}
@@ -315,6 +318,9 @@ func (c *Conn) handleMail(arg string) {
 
 		_, ok := args["SMTPUTF8"]
 		opts.UTF8 = ok
+
+		_, ok = args["REQUIRETLS"]
+		opts.RequireTLS = ok
 	}
 
 	if err := c.Session().Mail(from, opts); err != nil {

--- a/conn.go
+++ b/conn.go
@@ -234,6 +234,9 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 
 			caps = append(caps, authCap)
 		}
+		if c.server.EnableSMTPUTF8 {
+			caps = append(caps, "SMTPUTF8")
+		}
 		if c.server.MaxMessageBytes > 0 {
 			caps = append(caps, fmt.Sprintf("SIZE %v", c.server.MaxMessageBytes))
 		}
@@ -309,6 +312,9 @@ func (c *Conn) handleMail(arg string) {
 
 			opts.Size = int(size)
 		}
+
+		_, ok := args["SMTPUTF8"]
+		opts.UTF8 = ok
 	}
 
 	if err := c.Session().Mail(from, opts); err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -108,7 +108,7 @@ func (bkd *Backend) AnonymousLogin(state *smtp.ConnectionState) (smtp.Session, e
 // A Session is returned after successful login.
 type Session struct{}
 
-func (s *Session) Mail(from string) error {
+func (s *Session) Mail(from string, opts smtp.MailOptions) error {
 	log.Println("Mail from:", from)
 	return nil
 }

--- a/example_test.go
+++ b/example_test.go
@@ -25,7 +25,7 @@ func ExampleDial() {
 	}
 
 	// Set the sender and recipient first
-	if err := c.Mail("sender@example.org"); err != nil {
+	if err := c.Mail("sender@example.org", nil); err != nil {
 		log.Fatal(err)
 	}
 	if err := c.Rcpt("recipient@example.net"); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/emersion/go-smtp
 
 require github.com/emersion/go-sasl v0.0.0-20190704090222-36b50694675c
+
+go 1.13

--- a/server.go
+++ b/server.go
@@ -49,6 +49,10 @@ type Server struct {
 	// Should be used only if backend supports it.
 	EnableSMTPUTF8 bool
 
+	// Advertise REQUIRETLS (draft-ietf-uta-smtp-require-tls-09) capability.
+	// Should be used only if backend supports it.
+	EnableREQUIRETLS bool
+
 	// If set, the AUTH command will not be advertised and authentication
 	// attempts will be rejected. This setting overrides AllowInsecureAuth.
 	AuthDisabled bool

--- a/server.go
+++ b/server.go
@@ -45,6 +45,10 @@ type Server struct {
 	ReadTimeout       time.Duration
 	WriteTimeout      time.Duration
 
+	// Advertise SMTPUTF8 (RFC 6531) capability.
+	// Should be used only if backend supports it.
+	EnableSMTPUTF8 bool
+
 	// If set, the AUTH command will not be advertised and authentication
 	// attempts will be rejected. This setting overrides AllowInsecureAuth.
 	AuthDisabled bool

--- a/server_test.go
+++ b/server_test.go
@@ -61,7 +61,7 @@ func (s *session) Logout() error {
 	return nil
 }
 
-func (s *session) Mail(from string) error {
+func (s *session) Mail(from string, opts smtp.MailOptions) error {
 	if s.backend.panicOnMail {
 		panic("Everything is on fire!")
 	}

--- a/smtp.go
+++ b/smtp.go
@@ -6,6 +6,7 @@
 //	AUTH      		RFC 2554
 //	STARTTLS  		RFC 3207
 //	ENHANCEDSTATUSCODES	RFC 2034
+//  SMTPUTF8		RFC 6531
 //
 // LMTP (RFC 2033) is also supported.
 //

--- a/smtp.go
+++ b/smtp.go
@@ -7,6 +7,7 @@
 //	STARTTLS  		RFC 3207
 //	ENHANCEDSTATUSCODES	RFC 2034
 //  SMTPUTF8		RFC 6531
+//  REQUIRETLS		draft-ietf-uta-smtp-require-tls-09
 //
 // LMTP (RFC 2033) is also supported.
 //


### PR DESCRIPTION
I decided to go with MailExt for client instead of adding an argument to Mail
because most users probably don't care about optional arguments.

Closes #62.
Closes #67.