### PR TITLE
server: Don't call Session.Logout twice on QUIT command

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -167,6 +167,7 @@ func (c *Conn) SetSession(session Session) {
 func (c *Conn) Close() error {
 	if session := c.Session(); session != nil {
 		session.Logout()
+		c.SetSession(nil)
 	}
 
 	return c.conn.Close()


### PR DESCRIPTION
`case "QUIT"` in handle calls Conn.Close which calls Session.Logout, but then
it returns and Server.handleConn also calls Conn.Close which also calls
Session.Logout. While net.Conn is okay with double-close (it is ignored second
time), it might not be a good idea to call Session.Logout twice, so I changed
Conn.Close to reset session to nil after Logout so it will not call Logout on
second Close.