### PR TITLE
server: Rewrite MAIL FROM arguments handling 

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -37,7 +37,7 @@ func parseCmd(line string) (cmd string, arg string, err error) {
 // Takes the arguments proceeding a command and files them
 // into a map[string]string after uppercasing each key.  Sample arg
 // string:
-//		" BODY=8BITMIME SIZE=1024"
+//		" BODY=8BITMIME SIZE=1024 SMTPUTF8"
 // The leading space is mandatory.
 func parseArgs(args []string) (map[string]string, error) {
 	argMap := map[string]string{}
@@ -46,10 +46,14 @@ func parseArgs(args []string) (map[string]string, error) {
 			continue
 		}
 		m := strings.Split(arg, "=")
-		if len(m) != 2 {
+		switch len(m) {
+		case 2:
+			argMap[strings.ToUpper(m[0])] = m[1]
+		case 1:
+			argMap[strings.ToUpper(m[0])] = ""
+		default:
 			return nil, fmt.Errorf("Failed to parse arg string: %q", arg)
 		}
-		argMap[strings.ToUpper(m[0])] = m[1]
 	}
 	return argMap, nil
 }

--- a/server_test.go
+++ b/server_test.go
@@ -285,12 +285,41 @@ func TestServerPanicRecover(t *testing.T) {
 	return
 }
 
-func TestServerBadESMTPVar(t *testing.T) {
+func TestServerSMTPUTF8(t *testing.T) {
+	_, s, c, scanner := testServerAuthenticated(t)
+	s.EnableSMTPUTF8 = true
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "MAIL FROM:<alice@wonderland.book> SMTPUTF8\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "250 ") {
+		t.Fatal("Invalid MAIL response:", scanner.Text())
+	}
+
+	return
+}
+
+func TestServerSMTPUTF8_Disabled(t *testing.T) {
 	_, s, c, scanner := testServerAuthenticated(t)
 	defer s.Close()
 	defer c.Close()
 
-	io.WriteString(c, "MAIL FROM:<alice@wonderland.book> RABBIT\r\n")
+	io.WriteString(c, "MAIL FROM:<alice@wonderland.book> SMTPUTF8\r\n")
+	scanner.Scan()
+	if strings.HasPrefix(scanner.Text(), "250 ") {
+		t.Fatal("Invalid MAIL response:", scanner.Text())
+	}
+
+	return
+}
+
+func TestServerUnknownArg(t *testing.T) {
+	_, s, c, scanner := testServerAuthenticated(t)
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "MAIL FROM:<alice@wonderland.book> RABIIT\r\n")
 	scanner.Scan()
 	if strings.HasPrefix(scanner.Text(), "250 ") {
 		t.Fatal("Invalid MAIL response:", scanner.Text())


### PR DESCRIPTION
SMTPUTF8 and REQUIRETLS arguments are specified without the '=' sign.

Note to myself: If you think you can get away without writting tests for
something, you are terribly wrong and should suffer.