### PR TITLE
Fix sample code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ func (bkd *Backend) AnonymousLogin(state *smtp.ConnectionState) (smtp.Session, e
 // A Session is returned after successful login.
 type Session struct{}
 
-func (s *Session) Mail(from string) error {
+func (s *Session) Mail(from string, opts smtp.MailOptions) error {
 	log.Println("Mail from:", from)
 	return nil
 }


### PR DESCRIPTION
I tried the sample code in README and I met a build error like the following.

```
main.go:21:9: cannot use &Session literal (type *Session) as type smtp.Session in return argument:
        *Session does not implement smtp.Session (wrong type for Mail method)
                have Mail(string) error
                want Mail(string, smtp.MailOptions) error

```

### Environment

macOS 10.15.2
go version go1.13.1 darwin/amd64