### PR TITLE
server: Close the session on STARTTLS

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -490,7 +490,14 @@ func (c *Conn) handleStartTLS() {
 	c.conn = tlsConn
 	c.init()
 
-	// Reset envelope as a new EHLO/HELO is required after STARTTLS
+	// Reset all state and close the previous Session.
+	// This is different from just calling reset() since we want the Backend to
+	// be able to see the information about TLS connection in the
+	// ConnectionState object passed to it.
+	if session := c.Session(); session != nil {
+		session.Logout()
+		c.SetSession(nil)
+	}
 	c.reset()
 }
 


### PR DESCRIPTION
RFC 3207 Section 4.2:
>Upon completion of the TLS handshake, the SMTP protocol is reset to
>the initial state (the state in SMTP after a server issues a 220
>service ready greeting).  The server MUST discard any knowledge
>obtained from the client, ...

In particular, this caused the following malfunction in maddy:
```
< 220 mx.maddy.test ESMTP Service Ready
> EHLO localhost
...
> MAIL FROM:<testing@two.maddy.test>
* go-smtp Session is created, TLS ConnectionState is passed to Backend *
< 550 5.7.1 TLS conversation required (msg ID = 8b66d3a9)
> STARTTLS
< 220 2.0.0 Ready to start TLS
* TLS handshake happens *
> EHLO localhost
...
> MAIL FROM:<testing@two.maddy.test>
* It is still the same Session with stale empty TLS ConnectionState *
< 550 5.7.1 TLS conversation required (msg ID = c191f69a)
```