### PR TITLE
Properly handle AUTH= parameter for MAIL command

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -36,6 +36,15 @@ type MailOptions struct {
 	// The message envelope or message header contains UTF-8-encoded strings.
 	// This flag is set by SMTPUTF8-aware (RFC 6531) client.
 	UTF8 bool
+
+	// The authorization identity asserted by the message sender in decoded
+	// form with angle brackets stripped.
+	//
+	// nil value indicates missing AUTH, non-nil empty string indicates
+	// AUTH=<>.
+	//
+	// Defined in RFC 4954.
+	Auth *string
 }
 
 type Session interface {

--- a/client.go
+++ b/client.go
@@ -341,7 +341,12 @@ func (c *Client) Mail(from string, opts *MailOptions) error {
 			return errors.New("smtp: server does not support SMTPUTF8")
 		}
 	}
-
+	if opts != nil && opts.Auth != nil {
+		if _, ok := c.ext["AUTH"]; ok {
+			cmdStr += " AUTH=" + encodeXtext(*opts.Auth)
+		}
+		// We can safely discard parameter if server does not support AUTH.
+	}
 	_, _, err := c.cmd(250, cmdStr, from)
 	return err
 }


### PR DESCRIPTION
This PR adds both client-side and server-side support.
Closes #95.