### PR TITLE
Added SetLogHandler method on client.

### DIFF
--- a/client.go
+++ b/client.go
@@ -145,9 +145,9 @@ func (c *Client) Hello(localName string) error {
 	return c.hello()
 }
 
-func (c *Client) log(direction string, message string) {
+func (c *Client) log(message string) {
 	if c.logHandler != nil {
-		c.logHandler(direction, message)
+		c.logHandler(message)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/emersion/go-smtp
 
-require github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21
+require (
+	github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21
+	github.com/sirupsen/logrus v1.6.0 // indirect
+)
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,11 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21 h1:OJyUGMJTzHTd1XQp98QTaHernxMYzRaOasRir9hUlFQ=
 github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
+github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
I believe it fixes #48

I just wanted a way to specify more detailed logging.

Use it by 
```
c.SetLogHandler(func(message string) {
  log.Print(message)
})
```