### PR TITLE
server: Log TLS handshake errors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -559,6 +559,7 @@ func (c *Conn) handleStartTLS() {
 	tlsConn = tls.Server(c.conn, c.server.TLSConfig)
 
 	if err := tlsConn.Handshake(); err != nil {
+		c.server.ErrorLog.Printf("TLS handshake error for %s: %v", c.conn.RemoteAddr(), err)
 		c.WriteResponse(550, EnhancedCode{5, 0, 0}, "Handshake error")
 	}
 


### PR DESCRIPTION
Rationale: TLS handshake errors can reveal configuration
issues that otherwise would be invisible unless one
happens to run tcpdump at the right moment