### PR TITLE
fix: int64 converted to string with unclear type

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -430,7 +430,7 @@ func decodeXtext(val string) (string, error) {
 			return ""
 		}
 
-		return string(char)
+		return string(rune(char))
 	})
 	if replaceErr != nil {
 		return "", replaceErr
@@ -947,12 +947,12 @@ func (c *Conn) WriteResponse(code int, enhCode EnhancedCode, text ...string) {
 	}
 
 	for i := 0; i < len(text)-1; i++ {
-		c.text.PrintfLine("%v-%v", code, text[i])
+		c.text.PrintfLine("%d-%v", code, text[i])
 	}
 	if enhCode == NoEnhancedCode {
-		c.text.PrintfLine("%v %v", code, text[len(text)-1])
+		c.text.PrintfLine("%d %v", code, text[len(text)-1])
 	} else {
-		c.text.PrintfLine("%v %v.%v.%v %v", code, enhCode[0], enhCode[1], enhCode[2], text[len(text)-1])
+		c.text.PrintfLine("%d %v.%v.%v %v", code, enhCode[0], enhCode[1], enhCode[2], text[len(text)-1])
 	}
 }
 


### PR DESCRIPTION
On Golang 1.15, when executing `go test -buildmode pie -compiler gc`, it warns

```
conversion from int64 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```

and fails. The reason is that the type of the placeholde in formatting isn't specified. Also, explicit conversion (`string a_number`) isn't supported any longer (https://github.com/golang/go/issues/32479)