### PR TITLE
patch for sim*** controllers

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -956,8 +956,8 @@ func (c *Conn) WriteResponse(code int, enhCode EnhancedCode, text ...string) {
 	}
 
 	// Multiple tcp packets cause error
-	// in some controllers like sim800. reply must be a single tcp packet. 14.09.2020 ignatev vadim.
-	// example:
+	// in some controllers like sim800. reply must be in a single tcp packet. 
+	// sim800 behavior:
 	// s: 220 greets
 	// c: EHLO me
 	// s: 250-hello-me
@@ -965,7 +965,7 @@ func (c *Conn) WriteResponse(code int, enhCode EnhancedCode, text ...string) {
 	// s: 250-AUTH LOGIN
 	// c: AUTH LOGIN      <- client got previous packet and began authorization
 	// s: 250-STARTTLS    <- server keeps sending reply to EHLO
-	// c: error, disconnect. beacuse expected 334 VXNlcm5hbWU6
+	// c: error, disconnect. beacuse it expected 334 VXNlcm5hbWU6
 	// Essentially it is a client's problem. but...
 	reply := ""
 	for i := 0; i < len(text)-1; i++ {
@@ -978,16 +978,6 @@ func (c *Conn) WriteResponse(code int, enhCode EnhancedCode, text ...string) {
 	}
 	c.text.PrintfLine("%s", reply)
 
-	/*
-		for i := 0; i < len(text)-1; i++ {
-			c.text.PrintfLine("%d-%v", code, text[i])
-		}
-		if enhCode == NoEnhancedCode {
-			c.text.PrintfLine("%d %v", code, text[len(text)-1])
-		} else {
-			c.text.PrintfLine("%d %v.%v.%v %v", code, enhCode[0], enhCode[1], enhCode[2], text[len(text)-1])
-		}
-	*/
 }
 
 // Reads a line of input

--- a/conn.go
+++ b/conn.go
@@ -54,7 +54,7 @@ func newConn(c net.Conn, s *Server) *Conn {
 		server: s,
 		conn:   c,
 	}
-
+	//c.SetNoDelay(false) // tut
 	sc.init()
 	return sc
 }
@@ -969,7 +969,7 @@ func (c *Conn) WriteResponse(code int, enhCode EnhancedCode, text ...string) {
 	// Essentially it is a client's problem. but...
 	reply := ""
 	for i := 0; i < len(text)-1; i++ {
-		reply += fmt.Sprintf("%d-%v", code, text[i])
+		reply += fmt.Sprintf("%d-%v\r\n", code, text[i])
 	}
 	if enhCode == NoEnhancedCode {
 		reply += fmt.Sprintf("%d %v", code, text[len(text)-1])
@@ -977,6 +977,7 @@ func (c *Conn) WriteResponse(code int, enhCode EnhancedCode, text ...string) {
 		reply += fmt.Sprintf("%d %v.%v.%v %v", code, enhCode[0], enhCode[1], enhCode[2], text[len(text)-1])
 	}
 	c.text.PrintfLine("%s", reply)
+
 	/*
 		for i := 0; i < len(text)-1; i++ {
 			c.text.PrintfLine("%d-%v", code, text[i])
@@ -987,7 +988,6 @@ func (c *Conn) WriteResponse(code int, enhCode EnhancedCode, text ...string) {
 			c.text.PrintfLine("%d %v.%v.%v %v", code, enhCode[0], enhCode[1], enhCode[2], text[len(text)-1])
 		}
 	*/
-
 }
 
 // Reads a line of input

--- a/server.go
+++ b/server.go
@@ -122,7 +122,6 @@ func (s *Server) Serve(l net.Listener) error {
 				return err
 			}
 		}
-
 		go s.handleConn(newConn(c, s))
 	}
 }
@@ -181,7 +180,6 @@ func (s *Server) ListenAndServe() error {
 	if s.LMTP {
 		network = "unix"
 	}
-
 	addr := s.Addr
 	if !s.LMTP && addr == "" {
 		addr = ":smtp"
@@ -191,7 +189,6 @@ func (s *Server) ListenAndServe() error {
 	if err != nil {
 		return err
 	}
-
 	return s.Serve(l)
 }
 

--- a/server.go
+++ b/server.go
@@ -122,6 +122,7 @@ func (s *Server) Serve(l net.Listener) error {
 				return err
 			}
 		}
+
 		go s.handleConn(newConn(c, s))
 	}
 }
@@ -180,6 +181,7 @@ func (s *Server) ListenAndServe() error {
 	if s.LMTP {
 		network = "unix"
 	}
+
 	addr := s.Addr
 	if !s.LMTP && addr == "" {
 		addr = ":smtp"
@@ -189,6 +191,7 @@ func (s *Server) ListenAndServe() error {
 	if err != nil {
 		return err
 	}
+
 	return s.Serve(l)
 }
 


### PR DESCRIPTION
This server doesn't work with sim800 controller (and probably with all sim*** models) because multiline replies are sent in multiple tcp packets.  Controller ignores SMTP protocol (250- reply code) expecting that the reply is finished in one tcp packet. 
sim800 behavior:
s: 220 greets
c: EHLO me
s: 250-hello-me
s: 250-SIZE 111
s: 250-AUTH LOGIN
c: AUTH LOGIN      <- client got previous packet and began authorization
s: 250-STARTTLS    <- server keeps sending reply to EHLO
c: error, disconnect. beacuse it expected 334 VXNlcm5hbWU6
It's a totally client's bug but it can be easily fixed on the server side. Just by sending multiple lines reply in one write.