### PR TITLE
Enable LMTP over TCP

### DIFF
--- a/lmtp_server_test.go
+++ b/lmtp_server_test.go
@@ -268,7 +268,7 @@ func TestServer_LMTP_NoAddressError(t *testing.T) {
 	s.Addr = ""
 
 	err := s.ListenAndServe()
-	if err == nil || err.Error() != "lmtp: no port was defined and no default port exists for this protocol" {
+	if err == nil || err.Error() != "lmtp: no address was defined and no default port exists for this protocol" {
 		t.Fatalf("expected no default port error, got %v", err)
 	}
 }
@@ -284,7 +284,7 @@ func TestServer_LMTP_TLS_NoAddressError(t *testing.T) {
 	s.Addr = ""
 
 	err := s.ListenAndServeTLS()
-	if err == nil || err.Error() != "lmtp: no port was defined and no default port exists for this protocol" {
+	if err == nil || err.Error() != "lmtp: no address was defined and no default port exists for this protocol" {
 		t.Fatalf("expected no default port error, got %v", err)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/emersion/go-sasl"
 )
 
-var errTCPAndLMTP = errors.New("smtp: cannot start LMTP server listening on a TCP socket")
+var errNoAddressSpecified = errors.New("lmtp: no port was defined and no default port exists for this protocol")
 
 // A function that creates SASL servers.
 type SaslServerFactory func(conn *Conn) sasl.Server
@@ -30,9 +30,13 @@ type Server struct {
 	Addr string
 	// The server TLS configuration.
 	TLSConfig *tls.Config
-	// Enable LMTP mode, as defined in RFC 2033. LMTP mode cannot be used with a
-	// TCP listener.
+	// Enable LMTP mode, as defined in RFC 2033. While it is possible to run LMTP over TCP, it is not advisable to
+	// run a LMTP server on the public internet, as LMTP was only designed for local communication.
 	LMTP bool
+	// The network type this server listens on.
+	// It can be "tcp" for TCP/IP sockets, or "unix" for UNIX domain sockets.
+	// If it is blank, it defaults to "tcp" for SMTP servers, and "unix" for LMTP servers, to keep the previous behavior.
+	Network string
 
 	Domain            string
 	MaxRecipients     int
@@ -176,15 +180,20 @@ func (s *Server) handleConn(c *Conn) error {
 // to handle requests on incoming connections.
 //
 // If s.Addr is blank and LMTP is disabled, ":smtp" is used.
+// If s.Addr is blank and LMTP is enabled, an error is returned, as there is no default port for LMTP
 func (s *Server) ListenAndServe() error {
-	network := "tcp"
-	if s.LMTP {
+	network := s.Network
+	if !s.LMTP && network == "" {
+		network = "tcp"
+	} else if s.LMTP && network == "" {
 		network = "unix"
 	}
 
 	addr := s.Addr
 	if !s.LMTP && addr == "" {
 		addr = ":smtp"
+	} else if s.LMTP && addr == "" {
+		return errNoAddressSpecified
 	}
 
 	l, err := net.Listen(network, addr)
@@ -198,15 +207,14 @@ func (s *Server) ListenAndServe() error {
 // ListenAndServeTLS listens on the TCP network address s.Addr and then calls
 // Serve to handle requests on incoming TLS connections.
 //
-// If s.Addr is blank, ":smtps" is used.
+// If s.Addr is blank in SMTP mode, ":smtps" is used.
+// If s.Addr is blank in LMTP mode, an error is returned, as there is no default port for lmtps
 func (s *Server) ListenAndServeTLS() error {
-	if s.LMTP {
-		return errTCPAndLMTP
-	}
-
 	addr := s.Addr
-	if addr == "" {
+	if !s.LMTP && addr == "" {
 		addr = ":smtps"
+	} else if s.LMTP && addr == "" {
+		return errNoAddressSpecified
 	}
 
 	l, err := tls.Listen("tcp", addr, s.TLSConfig)

--- a/server.go
+++ b/server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/emersion/go-sasl"
 )
 
-var errNoAddressSpecified = errors.New("lmtp: no port was defined and no default port exists for this protocol")
+var errNoAddressSpecified = errors.New("lmtp: no address was defined and no default port exists for this protocol")
 
 // A function that creates SASL servers.
 type SaslServerFactory func(conn *Conn) sasl.Server


### PR DESCRIPTION
Changes:
 - remove check that forbids LMTP over TCP
 - introduce Network config option, to choose between TCP and unix sockets
 - add a warning to the documentation that LMTP offers no authentication and should not be hosted unprotected
