### PR TITLE
Add SIZE extension when MaxMessageBytes not set

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -275,6 +275,8 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 		}
 		if c.server.MaxMessageBytes > 0 {
 			caps = append(caps, fmt.Sprintf("SIZE %v", c.server.MaxMessageBytes))
+		} else {
+			caps = append(caps, "SIZE")
 		}
 
 		args := []string{"Hello " + domain}


### PR DESCRIPTION
According to [RFC 1870](https://tools.ietf.org/html/rfc1870) SIZE should always be in extension list if it is supported by the server. Just without max size. Now 

```
250-PIPELINING
250-8BITMIME
250-ENHANCEDSTATUSCODES
250-CHUNKING
250-AUTH PLAIN
250 BINARYMIME
```
Should be

```
250-Hello test
250-PIPELINING
250-8BITMIME
250-ENHANCEDSTATUSCODES
250-CHUNKING
250-AUTH PLAIN
250-BINARYMIME
250 SIZE
```
