### PR TITLE
Disable lineLimitReader when handle BDAT data

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -741,12 +741,8 @@ func (c *Conn) handleBdat(arg string) {
 		}()
 	}
 
-	prevLineLimit := c.lineLimitReader.LineLimit
 	c.lineLimitReader.LineLimit = 0
-	recoverLineLimit := func() {
-		c.lineLimitReader.LineLimit = prevLineLimit
-	}
-	defer recoverLineLimit()
+
 	chunk := io.LimitReader(c.text.R, int64(size))
 	_, err = io.Copy(c.bdatPipe, chunk)
 	if err != nil {
@@ -767,6 +763,8 @@ func (c *Conn) handleBdat(arg string) {
 	c.bytesReceived += int(size)
 
 	if last {
+		c.lineLimitReader.LineLimit = c.server.MaxLineLength
+
 		c.bdatPipe.Close()
 
 		err := <-c.dataResult

--- a/conn.go
+++ b/conn.go
@@ -743,10 +743,10 @@ func (c *Conn) handleBdat(arg string) {
 
 	prevLineLimit := c.lineLimitReader.LineLimit
 	c.lineLimitReader.LineLimit = 0
-	recover := func() {
+	recoverLineLimit := func() {
 		c.lineLimitReader.LineLimit = prevLineLimit
 	}
-	defer recover()
+	defer recoverLineLimit()
 	chunk := io.LimitReader(c.text.R, int64(size))
 	_, err = io.Copy(c.bdatPipe, chunk)
 	if err != nil {

--- a/conn.go
+++ b/conn.go
@@ -739,7 +739,7 @@ func (c *Conn) handleBdat(arg string) {
 		}()
 	}
 
-	chunk := io.LimitReader(c.text.R, int64(size))
+	chunk := io.LimitReader(c.conn, int64(size))
 	_, err = io.Copy(c.bdatPipe, chunk)
 	if err != nil {
 		// Backend might return an error early using CloseWithError without consuming

--- a/conn.go
+++ b/conn.go
@@ -743,6 +743,10 @@ func (c *Conn) handleBdat(arg string) {
 
 	prevLineLimit := c.lineLimitReader.LineLimit
 	c.lineLimitReader.LineLimit = 0
+	recover := func() {
+		c.lineLimitReader.LineLimit = prevLineLimit
+	}
+	defer recover()
 	chunk := io.LimitReader(c.text.R, int64(size))
 	_, err = io.Copy(c.bdatPipe, chunk)
 	if err != nil {
@@ -757,7 +761,6 @@ func (c *Conn) handleBdat(arg string) {
 		}
 
 		c.reset()
-		c.lineLimitReader.LineLimit = prevLineLimit
 		return
 	}
 
@@ -780,7 +783,6 @@ func (c *Conn) handleBdat(arg string) {
 
 		if err == errPanic {
 			c.Close()
-			c.lineLimitReader.LineLimit = prevLineLimit
 			return
 		}
 
@@ -788,7 +790,6 @@ func (c *Conn) handleBdat(arg string) {
 	} else {
 		c.WriteResponse(250, EnhancedCode{2, 0, 0}, "Continue")
 	}
-	c.lineLimitReader.LineLimit = prevLineLimit
 }
 
 // ErrDataReset is returned by Reader pased to Data function if client does not

--- a/conn.go
+++ b/conn.go
@@ -757,6 +757,7 @@ func (c *Conn) handleBdat(arg string) {
 		}
 
 		c.reset()
+		c.lineLimitReader.LineLimit = c.server.MaxLineLength
 		return
 	}
 

--- a/lengthlimit_reader.go
+++ b/lengthlimit_reader.go
@@ -12,14 +12,15 @@ var ErrTooLongLine = errors.New("smtp: too longer line in input stream")
 //
 // If line length exceeds the limit - Read returns ErrTooLongLine
 type lineLimitReader struct {
-	R         io.Reader
-	LineLimit int
+	R            io.Reader
+	LineLimit    int
+	DisableCheck bool
 
 	curLineLength int
 }
 
 func (r *lineLimitReader) Read(b []byte) (int, error) {
-	if r.curLineLength > r.LineLimit {
+	if r.curLineLength > r.LineLimit && !r.DisableCheck {
 		return 0, ErrTooLongLine
 	}
 
@@ -28,7 +29,7 @@ func (r *lineLimitReader) Read(b []byte) (int, error) {
 		return n, err
 	}
 
-	if r.LineLimit == 0 {
+	if r.LineLimit == 0 || r.DisableCheck {
 		return n, nil
 	}
 

--- a/lengthlimit_reader.go
+++ b/lengthlimit_reader.go
@@ -12,15 +12,14 @@ var ErrTooLongLine = errors.New("smtp: too longer line in input stream")
 //
 // If line length exceeds the limit - Read returns ErrTooLongLine
 type lineLimitReader struct {
-	R            io.Reader
-	LineLimit    int
-	DisableCheck bool
+	R         io.Reader
+	LineLimit int
 
 	curLineLength int
 }
 
 func (r *lineLimitReader) Read(b []byte) (int, error) {
-	if r.curLineLength > r.LineLimit && !r.DisableCheck {
+	if r.curLineLength > r.LineLimit && r.LineLimit > 0 {
 		return 0, ErrTooLongLine
 	}
 
@@ -29,7 +28,7 @@ func (r *lineLimitReader) Read(b []byte) (int, error) {
 		return n, err
 	}
 
-	if r.LineLimit == 0 || r.DisableCheck {
+	if r.LineLimit == 0 {
 		return n, nil
 	}
 


### PR DESCRIPTION
We can fix this problem https://github.com/emersion/go-smtp/issues/81#issuecomment-801659120

By add checkflag to disable limit checking on handle BDAT data