### PR TITLE
Change smtp.MailOptions to a pointer

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -72,7 +72,7 @@ type Session interface {
 	AuthPlain(username, password string) error
 
 	// Set return path for currently processed message.
-	Mail(from string, opts MailOptions) error
+	Mail(from string, opts *MailOptions) error
 	// Add recipient for currently processed message.
 	Rcpt(to string) error
 	// Set currently processed message contents and send it.

--- a/backendutil/transform.go
+++ b/backendutil/transform.go
@@ -37,7 +37,7 @@ func (s *transformSession) AuthPlain(username, password string) error {
 	return s.Session.AuthPlain(username, password)
 }
 
-func (s *transformSession) Mail(from string, opts smtp.MailOptions) error {
+func (s *transformSession) Mail(from string, opts *smtp.MailOptions) error {
 	if s.be.TransformMail != nil {
 		var err error
 		from, err = s.be.TransformMail(from)

--- a/backendutil/transform_test.go
+++ b/backendutil/transform_test.go
@@ -56,7 +56,7 @@ func (s *session) AuthPlain(username, password string) error {
 	return nil
 }
 
-func (s *session) Mail(from string, opts smtp.MailOptions) error {
+func (s *session) Mail(from string, opts *smtp.MailOptions) error {
 	if s.backend.userErr != nil {
 		return s.backend.userErr
 	}

--- a/cmd/smtp-debug-server/main.go
+++ b/cmd/smtp-debug-server/main.go
@@ -27,7 +27,7 @@ func (s *session) AuthPlain(username, password string) error {
 	return nil
 }
 
-func (s *session) Mail(from string, opts smtp.MailOptions) error {
+func (s *session) Mail(from string, opts *smtp.MailOptions) error {
 	return nil
 }
 

--- a/conn.go
+++ b/conn.go
@@ -321,7 +321,7 @@ func (c *Conn) handleMail(arg string) {
 	}
 	from = strings.Trim(from, "<>")
 
-	opts := MailOptions{}
+	opts := &MailOptions{}
 
 	c.binarymime = false
 	// This is where the Conn may put BODY=8BITMIME, but we already

--- a/example_test.go
+++ b/example_test.go
@@ -108,7 +108,7 @@ func (s *Session) AuthPlain(username, password string) error {
 	return nil
 }
 
-func (s *Session) Mail(from string, opts smtp.MailOptions) error {
+func (s *Session) Mail(from string, opts *smtp.MailOptions) error {
 	log.Println("Mail from:", from)
 	return nil
 }

--- a/server_test.go
+++ b/server_test.go
@@ -17,7 +17,7 @@ type message struct {
 	From string
 	To   []string
 	Data []byte
-	Opts smtp.MailOptions
+	Opts *smtp.MailOptions
 }
 
 type backend struct {
@@ -79,7 +79,7 @@ func (s *session) Logout() error {
 	return nil
 }
 
-func (s *session) Mail(from string, opts smtp.MailOptions) error {
+func (s *session) Mail(from string, opts *smtp.MailOptions) error {
 	if s.backend.userErr != nil {
 		return s.backend.userErr
 	}


### PR DESCRIPTION
Pass a pointer instead of the struct copy.
Will require a corresponding change in https://github.com/emersion/go-smtp-proxy