### PR TITLE
server: Expose smtp.Conn to backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ import (
 // The Backend implements SMTP server methods.
 type Backend struct{}
 
-func (bkd *Backend) NewSession(_ smtp.ConnectionState) (smtp.Session, error) {
+func (bkd *Backend) NewSession(_ *smtp.Conn) (smtp.Session, error) {
 	return &Session{}, nil
 }
 

--- a/backend.go
+++ b/backend.go
@@ -19,7 +19,7 @@ var (
 
 // A SMTP server backend.
 type Backend interface {
-	NewSession(c ConnectionState) (Session, error)
+	NewSession(c *Conn) (Session, error)
 }
 
 type BodyType string

--- a/backendutil/transform.go
+++ b/backendutil/transform.go
@@ -15,7 +15,7 @@ type TransformBackend struct {
 	TransformData func(r io.Reader) (io.Reader, error)
 }
 
-func (be *TransformBackend) NewSession(c smtp.ConnectionState) (smtp.Session, error) {
+func (be *TransformBackend) NewSession(c *smtp.Conn) (smtp.Session, error) {
 	sess, err := be.Backend.NewSession(c)
 	if err != nil {
 		return nil, err

--- a/backendutil/transform_test.go
+++ b/backendutil/transform_test.go
@@ -29,7 +29,7 @@ type backend struct {
 	userErr error
 }
 
-func (be *backend) NewSession(c smtp.ConnectionState) (smtp.Session, error) {
+func (be *backend) NewSession(c *smtp.Conn) (smtp.Session, error) {
 	return &session{backend: be, anonymous: true}, nil
 }
 

--- a/cmd/smtp-debug-server/main.go
+++ b/cmd/smtp-debug-server/main.go
@@ -17,7 +17,7 @@ func init() {
 
 type backend struct{}
 
-func (bkd *backend) NewSession(c smtp.ConnectionState) (smtp.Session, error) {
+func (bkd *backend) NewSession(c *smtp.Conn) (smtp.Session, error) {
 	return &session{}, nil
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -93,7 +93,7 @@ func ExampleSendMail() {
 type Backend struct{}
 
 // NewSession is called after client greeting (EHLO, HELO).
-func (bkd *Backend) NewSession(c smtp.ConnectionState) (smtp.Session, error) {
+func (bkd *Backend) NewSession(c *smtp.Conn) (smtp.Session, error) {
 	return &Session{}, nil
 }
 

--- a/server.go
+++ b/server.go
@@ -172,7 +172,7 @@ func (s *Server) handleConn(c *Conn) error {
 	c.greet()
 
 	for {
-		line, err := c.ReadLine()
+		line, err := c.readLine()
 		if err == nil {
 			cmd, arg, err := parseCmd(line)
 			if err != nil {
@@ -186,16 +186,16 @@ func (s *Server) handleConn(c *Conn) error {
 				return nil
 			}
 			if err == ErrTooLongLine {
-				c.WriteResponse(500, EnhancedCode{5, 4, 0}, "Too long line, closing connection")
+				c.writeResponse(500, EnhancedCode{5, 4, 0}, "Too long line, closing connection")
 				return nil
 			}
 
 			if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
-				c.WriteResponse(221, EnhancedCode{2, 4, 2}, "Idle timeout, bye bye")
+				c.writeResponse(221, EnhancedCode{2, 4, 2}, "Idle timeout, bye bye")
 				return nil
 			}
 
-			c.WriteResponse(221, EnhancedCode{2, 4, 0}, "Connection error, sorry")
+			c.writeResponse(221, EnhancedCode{2, 4, 0}, "Connection error, sorry")
 			return err
 		}
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -45,7 +45,7 @@ type backend struct {
 	userErr     error
 }
 
-func (be *backend) NewSession(_ smtp.ConnectionState) (smtp.Session, error) {
+func (be *backend) NewSession(_ *smtp.Conn) (smtp.Session, error) {
 	if be.implementLMTPData {
 		return &lmtpSession{&session{backend: be, anonymous: true}}, nil
 	}


### PR DESCRIPTION
Here is the rough idea of how I would resolve #147.

* `*smtp.Conn` is passed to NewSession
* ConnectionState type and Conn.State is removed
* Conn.Hostname to get HELO name
* Conn.Conn to access net.Conn
* Conn.WriteResponse, Conn.ReadLine, Conn.SetSession unexported as these should not be used by backends directly
* Conn.Reject is left as is, not sure whether it should be removed/changed anyhow
* Conn.TLSConnectionState is left as is as a shortcut.

Closes #147.