### PR TITLE
Fix Sample Server Code To Actually Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ func (bkd *Backend) NewSession(_ smtp.ConnectionState, _ string) (smtp.Session, 
 	return &Session{}, nil
 }
 
+func (bkd *Backend) AnonymousLogin(_ *smtp.ConnectionState) (smtp.Session, error) {
+	return &Session{}, nil
+}
+
+func (bkd *Backend) Login(_ *smtp.ConnectionState, username string, password string) (smtp.Session, error) {
+	return &Session{}, nil
+}
+
 // A Session is returned after EHLO.
 type Session struct{}
 
@@ -79,7 +87,7 @@ func (s *Session) AuthPlain(username, password string) error {
 	return nil
 }
 
-func (s *Session) Mail(from string, opts *smtp.MailOptions) error {
+func (s *Session) Mail(from string, opts smtp.MailOptions) error {
 	log.Println("Mail from:", from)
 	return nil
 }


### PR DESCRIPTION
The prior code didn't run/work - with these changes there's now a "hello world" that actually runs the server.

Original Errors:
# command-line-arguments
./server.go:17:9: cannot use &Session{} (type *Session) as type smtp.Session in return argument:
	*Session does not implement smtp.Session (wrong type for Mail method)
		have Mail(string, *smtp.MailOptions) error
		want Mail(string, smtp.MailOptions) error
./server.go:58:21: cannot use be (type *Backend) as type smtp.Backend in argument to smtp.NewServer:
	*Backend does not implement smtp.Backend (missing AnonymousLogin method)