### PR TITLE
server: stop logging TLS handshake errors in ErrorLog

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -599,7 +599,6 @@ func (c *Conn) handleStartTLS() {
 	tlsConn := tls.Server(c.conn, c.server.TLSConfig)
 
 	if err := tlsConn.Handshake(); err != nil {
-		c.server.ErrorLog.Printf("TLS handshake error for %s: %v", c.conn.RemoteAddr(), err)
 		c.WriteResponse(550, EnhancedCode{5, 0, 0}, "Handshake error")
 		return
 	}

--- a/server.go
+++ b/server.go
@@ -146,7 +146,6 @@ func (s *Server) handleConn(c *Conn) error {
 			c.conn.SetWriteDeadline(time.Now().Add(d))
 		}
 		if err := tlsConn.Handshake(); err != nil {
-			s.ErrorLog.Printf("TLS handshake error for %s: %v", tlsConn.RemoteAddr(), err)
 			return err
 		}
 	}


### PR DESCRIPTION
ErrorLog is meant for panic logging only. It should only be used
for logging server implementation bugs, not for logging client
runtime errors.