### PR TITLE
Remove hostname argument from the NewSession method

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ import (
 // The Backend implements SMTP server methods.
 type Backend struct{}
 
-func (bkd *Backend) NewSession(_ smtp.ConnectionState, _ string) (smtp.Session, error) {
+func (bkd *Backend) NewSession(_ smtp.ConnectionState) (smtp.Session, error) {
 	return &Session{}, nil
 }
 

--- a/backend.go
+++ b/backend.go
@@ -5,20 +5,21 @@ import (
 )
 
 var (
-	ErrAuthRequired    = &SMTPError{
-		Code: 502,
+	ErrAuthRequired = &SMTPError{
+		Code:         502,
 		EnhancedCode: EnhancedCode{5, 7, 0},
-		Message: "Please authenticate first",
+		Message:      "Please authenticate first",
 	}
-	ErrAuthUnsupported    = &SMTPError{
-		Code: 502,
+	ErrAuthUnsupported = &SMTPError{
+		Code:         502,
 		EnhancedCode: EnhancedCode{5, 7, 0},
-		Message: "Authentication not supported",
-	})
+		Message:      "Authentication not supported",
+	}
+)
 
 // A SMTP server backend.
 type Backend interface {
-	NewSession(c ConnectionState, hostname string) (Session, error)
+	NewSession(c ConnectionState) (Session, error)
 }
 
 type BodyType string

--- a/backendutil/transform.go
+++ b/backendutil/transform.go
@@ -15,8 +15,8 @@ type TransformBackend struct {
 	TransformData func(r io.Reader) (io.Reader, error)
 }
 
-func (be *TransformBackend) NewSession(c smtp.ConnectionState, hostname string) (smtp.Session, error) {
-	sess, err := be.Backend.NewSession(c, hostname)
+func (be *TransformBackend) NewSession(c smtp.ConnectionState) (smtp.Session, error) {
+	sess, err := be.Backend.NewSession(c)
 	if err != nil {
 		return nil, err
 	}

--- a/backendutil/transform_test.go
+++ b/backendutil/transform_test.go
@@ -29,7 +29,7 @@ type backend struct {
 	userErr error
 }
 
-func (be *backend) NewSession(c smtp.ConnectionState, hostname string) (smtp.Session, error) {
+func (be *backend) NewSession(c smtp.ConnectionState) (smtp.Session, error) {
 	return &session{backend: be, anonymous: true}, nil
 }
 

--- a/cmd/smtp-debug-server/main.go
+++ b/cmd/smtp-debug-server/main.go
@@ -17,7 +17,7 @@ func init() {
 
 type backend struct{}
 
-func (bkd *backend) NewSession(c smtp.ConnectionState, hostname string) (smtp.Session, error) {
+func (bkd *backend) NewSession(c smtp.ConnectionState) (smtp.Session, error) {
 	return &session{}, nil
 }
 

--- a/conn.go
+++ b/conn.go
@@ -243,7 +243,7 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 	}
 	c.helo = domain
 
-	sess, err := c.server.Backend.NewSession(c.State(), domain)
+	sess, err := c.server.Backend.NewSession(c.State())
 	if err != nil {
 		if smtpErr, ok := err.(*SMTPError); ok {
 			c.WriteResponse(smtpErr.Code, smtpErr.EnhancedCode, smtpErr.Message)

--- a/example_test.go
+++ b/example_test.go
@@ -93,7 +93,7 @@ func ExampleSendMail() {
 type Backend struct{}
 
 // NewSession is called after client greeting (EHLO, HELO).
-func (bkd *Backend) NewSession(c smtp.ConnectionState, hostname string) (smtp.Session, error) {
+func (bkd *Backend) NewSession(c smtp.ConnectionState) (smtp.Session, error) {
 	return &Session{}, nil
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -44,7 +44,7 @@ type backend struct {
 	userErr     error
 }
 
-func (be *backend) NewSession(_ smtp.ConnectionState, _ string) (smtp.Session, error) {
+func (be *backend) NewSession(_ smtp.ConnectionState) (smtp.Session, error) {
 	if be.implementLMTPData {
 		return &lmtpSession{&session{backend: be, anonymous: true}}, nil
 	}


### PR DESCRIPTION
Client's hostname is already available inside the `ConnectionState` struct:

https://github.com/emersion/go-smtp/blob/30169acc42e795e5d35ce901c8387950b103dfd9/conn.go#L238-L246

https://github.com/emersion/go-smtp/blob/30169acc42e795e5d35ce901c8387950b103dfd9/conn.go#L206-L213