### PR TITLE
Add ServerDomain member into the ConnectionState struct

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -21,10 +21,11 @@ import (
 const errThreshold = 3
 
 type ConnectionState struct {
-	Hostname   string
-	LocalAddr  net.Addr
-	RemoteAddr net.Addr
-	TLS        tls.ConnectionState
+	ServerDomain string
+	Hostname     string
+	LocalAddr    net.Addr
+	RemoteAddr   net.Addr
+	TLS          tls.ConnectionState
 }
 
 type Conn struct {
@@ -210,6 +211,7 @@ func (c *Conn) State() ConnectionState {
 		state.TLS = tlsState
 	}
 
+	state.ServerDomain = c.server.Domain
 	state.Hostname = c.helo
 	state.LocalAddr = c.conn.LocalAddr()
 	state.RemoteAddr = c.conn.RemoteAddr()


### PR DESCRIPTION
Add server's hostname (domain)  into the `ConnectionState` struct.
It can be used for logging purposes.