### PR TITLE
Improved error handling in Server.Serve

### DIFF
--- a/server.go
+++ b/server.go
@@ -109,6 +109,8 @@ func (s *Server) Serve(l net.Listener) error {
 	s.listeners = append(s.listeners, l)
 	s.locker.Unlock()
 
+	var tempDelay time.Duration // how long to sleep on accept failure
+
 	for {
 		c, err := l.Accept()
 		if err != nil {
@@ -117,11 +119,28 @@ func (s *Server) Serve(l net.Listener) error {
 				// we called Close()
 				return nil
 			default:
-				return err
 			}
+			if ne, ok := err.(net.Error); ok && ne.Temporary() {
+				if tempDelay == 0 {
+					tempDelay = 5 * time.Millisecond
+				} else {
+					tempDelay *= 2
+				}
+				if max := 1 * time.Second; tempDelay > max {
+					tempDelay = max
+				}
+				s.ErrorLog.Printf("accept error: %s; retrying in %s", err, tempDelay)
+				time.Sleep(tempDelay)
+				continue
+			}
+			return err
 		}
-
-		go s.handleConn(newConn(c, s))
+		go func() {
+			err := s.handleConn(newConn(c, s))
+			if err != nil {
+				s.ErrorLog.Printf("handler error: %s", err)
+			}
+		}()
 	}
 }
 


### PR DESCRIPTION
Hey, not sure if you'd like the test implementation (that mock listener might be a bit weird - if you feel so, would appreciate any suggestions on how it can be improved) but here is what I came up with to address #180.

Now `Serve` does not exit on non-fatal errors from `Accept`. It also logs `handleConn` errors to the `ErrorLog` - which is not a solution but should be a partial improvement for #167.