### PR TITLE
Read server response on DATA command

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -33,7 +33,7 @@ func ExampleDial() {
 	}
 
 	// Send the email body.
-	wc, err := c.Data()
+	wc, err := c.Data(nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This is a braking change. Now `Data()` method will accept a callaback function and `LMTPData()` method callbacks will receive success statuses instead nil. Therefore dependent `LMTPData` code must check for status response code.

Resolves #189 

P.S. I rewrote the `(d *dataCloser) Close()` code to make it more readable.