### PR TITLE
Close connection if Backend.NewSession() returns an error

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -233,9 +233,11 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 	if err != nil {
 		if smtpErr, ok := err.(*SMTPError); ok {
 			c.writeResponse(smtpErr.Code, smtpErr.EnhancedCode, smtpErr.Message)
+			c.Close()
 			return
 		}
 		c.writeResponse(451, EnhancedCode{4, 0, 0}, err.Error())
+		c.Close()
 		return
 	}
 	c.setSession(sess)


### PR DESCRIPTION
If `c.server.Backend.NewSession(c)` returns an error at `conn.go:232`, `handleGreet` sets `c.helo` but returns without calling `c.setSession()`. If the client then issues a `MAIL` command, `handleMail` panics when it tries to dereference `c.Session()`:

SMTP session:
````220 cmail.example.org ESMTP Service Ready
EHLO dev.example.org
554 0.7.0 Error during policy check
MAIL FROM:someone@example.org
421 4.0.0 Internal server error
````

Output:
````Sep 13 14:43:52 cmail maddy[7298]: smtp: panic serving 10.2.3.4:51150: runtime error: invalid memory address or nil pointer dereference
Sep 13 14:43:52 cmail maddy[7298]: goroutine 50 [running]:
Sep 13 14:43:52 cmail maddy[7298]: runtime/debug.Stack()
Sep 13 14:43:52 cmail maddy[7298]:         runtime/debug/stack.go:24 +0x65
Sep 13 14:43:52 cmail maddy[7298]: github.com/emersion/go-smtp.(*Conn).handle.func1()
Sep 13 14:43:52 cmail maddy[7298]:         github.com/emersion/go-smtp@v0.15.1-0.20220119142625-1c322d2783aa/conn.go:103 +0xc5
Sep 13 14:43:52 cmail maddy[7298]: panic({0xf15960, 0x1860b50})
Sep 13 14:43:52 cmail maddy[7298]:         runtime/panic.go:1038 +0x215
Sep 13 14:43:52 cmail maddy[7298]: github.com/emersion/go-smtp.(*Conn).handleMail(0xc00039fad0, {0xc0001e118d, 0x12})
Sep 13 14:43:52 cmail maddy[7298]:         github.com/emersion/go-smtp@v0.15.1-0.20220119142625-1c322d2783aa/conn.go:401 +0xc3f
Sep 13 14:43:52 cmail maddy[7298]: github.com/emersion/go-smtp.(*Conn).handle(0xc00039fad0, {0xc0001e1188, 0xc00039fad0}, {0xc0001e118d, 0x12})
Sep 13 14:43:52 cmail maddy[7298]:         github.com/emersion/go-smtp@v0.15.1-0.20220119142625-1c322d2783aa/conn.go:131 +0x411
Sep 13 14:43:52 cmail maddy[7298]: github.com/emersion/go-smtp.(*Server).handleConn(0xc0003280f0, 0xc00039fad0)
Sep 13 14:43:52 cmail maddy[7298]:         github.com/emersion/go-smtp@v0.15.1-0.20220119142625-1c322d2783aa/server.go:164 +0x2cb
Sep 13 14:43:52 cmail maddy[7298]: created by github.com/emersion/go-smtp.(*Server).Serve
Sep 13 14:43:52 cmail maddy[7298]:         github.com/emersion/go-smtp@v0.15.1-0.20220119142625-1c322d2783aa/server.go:124 +0x169
````

This trivial patch just closes the connection if NewSession() returns an error, since there's not much else that can be done at that point.