### PR TITLE
server: handle error after closing connection

### DIFF
--- a/server.go
+++ b/server.go
@@ -182,7 +182,7 @@ func (s *Server) handleConn(c *Conn) error {
 
 			c.handle(cmd, arg)
 		} else {
-			if err == io.EOF {
+			if err == io.EOF || errors.Is(err, net.ErrClosed) {
 				return nil
 			}
 			if err == ErrTooLongLine {


### PR DESCRIPTION
Reading from the underlying server connection may fail because it was closed either from the client or the server side.

Currently we only handle the former case by checking for `io.EOF`. If the server terminates the connection, we get a handler error: `use of closed network connection`.

This fix is similar to the server connection handling in [go-imap.](https://github.com/emersion/go-imap/blob/master/server/conn.go#L321)