### PR TITLE
Custom server greeting

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -970,7 +970,11 @@ func (c *Conn) Reject() {
 }
 
 func (c *Conn) greet() {
-	c.writeResponse(220, NoEnhancedCode, fmt.Sprintf("%v ESMTP Service Ready", c.server.Domain))
+	name := "Service Ready"
+	if len(c.server.Name) > 0 {
+		name = c.server.Name
+	}
+	c.writeResponse(220, NoEnhancedCode, fmt.Sprintf("%v ESMTP %v", c.server.Domain, name))
 }
 
 func (c *Conn) writeResponse(code int, enhCode EnhancedCode, text ...string) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -261,3 +261,29 @@ func TestHandleNaturalFromDefectOptions(t *testing.T) {
 		t.Errorf("Expected 501 5.5.2 Was expecting MAIL arg syntax of FROM:<address> got %s", ret)
 	}
 }
+
+func TestHandleGreetingDefault(t *testing.T) {
+	con, tester := newTestConn()
+	con.greet()
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	ret := string(tester.out[0])
+	if ret != "220  ESMTP Service Ready\r\n" {
+		t.Errorf("Expected 220  ESMTP Service Ready got %s", ret)
+	}
+}
+
+func TestHandleGreeting(t *testing.T) {
+	con, tester := newTestConn()
+	con.server.Name = "Name"
+	con.server.Domain = "Domain"
+	con.greet()
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	ret := string(tester.out[0])
+	if ret != "220 Domain ESMTP Name\r\n" {
+		t.Errorf("Expected 220 Domain ESMTP Name got %s", ret)
+	}
+}

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,263 @@
+package smtp
+
+import (
+	"io"
+	"net/textproto"
+	"testing"
+)
+
+type dummyBackend struct {
+	mailFrom string
+	opts     MailOptions
+}
+
+func (d *dummyBackend) Reset() {}
+
+func (d *dummyBackend) Logout() error {
+	return nil
+}
+
+func (d *dummyBackend) AuthPlain(username, password string) error {
+	return nil
+}
+
+func (d *dummyBackend) Mail(from string, opts *MailOptions) error {
+	d.mailFrom = from
+	d.opts = *opts
+	return nil
+}
+
+func (d *dummyBackend) Rcpt(to string) error {
+	return nil
+}
+
+func (d *dummyBackend) Data(r io.Reader) error {
+	return nil
+}
+
+type testReadWriter struct {
+	io.Reader
+	io.Writer
+	io.Closer
+	out [][]byte
+}
+
+func (c *testReadWriter) Write(p []byte) (n int, err error) {
+	c.out = append(c.out, p)
+	return len(p), nil
+}
+
+func (c *testReadWriter) Flush() (err error) {
+	return nil
+}
+
+func newTestConn() (con Conn, tester *testReadWriter) {
+	tester = &testReadWriter{}
+	con.text = textproto.NewConn(tester)
+	con.server = &Server{}
+	db := &dummyBackend{}
+	con.session = db
+	con.helo = "helo"
+	return
+}
+
+func TestHandleEmptyFrom(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM:")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	ret := string(tester.out[0])
+	if ret != "501 5.5.2 Was expecting MAIL arg syntax of FROM:<address>\r\n" {
+		t.Errorf("Expected 501 5.5.2 Was expecting MAIL arg syntax of FROM:<address>\r\n, got %s", ret)
+	}
+}
+
+func TestHandleEmptyValidFrom(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM:<>")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	ret := string(tester.out[0])
+	if ret != "250 2.0.0 Roger, accepting mail from <>\r\n" {
+		t.Errorf("Expected 501 5.5.2 Was expecting MAIL arg syntax of FROM:<address>\r\n, got %s", ret)
+	}
+}
+
+func TestHandleFromServerTest(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM: root@nsa.gov AUTH=<hey+41>")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	if *con.session.(*dummyBackend).opts.Auth != "heyA" {
+		t.Errorf("Expected heyA, got %s", *con.session.(*dummyBackend).opts.Auth)
+	}
+	ret := string(tester.out[0])
+	if ret != "250 2.0.0 Roger, accepting mail from <root@nsa.gov>\r\n" {
+		t.Errorf("Expected 501 5.5.2 Was expecting MAIL arg syntax of FROM:<address>\r\n, got %s", ret)
+	}
+}
+
+func TestHandleFromServerTestAuthShort(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM: root@nsa.gov AUTH=<hey+A>")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	ret := string(tester.out[0])
+	if ret != "500 5.5.4 Malformed AUTH parameter value\r\n" {
+		t.Errorf("Expected 501 5.5.2 Was expecting MAIL arg syntax of FROM:<address>\r\n, got %s", ret)
+	}
+}
+
+func TestHandleSimpleFrom(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM:test@bla.de")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	if con.session.(*dummyBackend).mailFrom != "test@bla.de" {
+		t.Errorf("Expected test@bla.de, got %s", con.session.(*dummyBackend).mailFrom)
+	}
+	ret := string(tester.out[0])
+	if ret != "250 2.0.0 Roger, accepting mail from <test@bla.de>\r\n" {
+		t.Errorf("Expected 250 2.0.0 Roger, accepting mail from <test@bla> got %s", ret)
+	}
+}
+
+func TestHandleSimpleSharpFrom(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM:<test@bla.de>")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	if con.session.(*dummyBackend).mailFrom != "test@bla.de" {
+		t.Errorf("Expected test@bla.de, got %s", con.session.(*dummyBackend).mailFrom)
+	}
+	ret := string(tester.out[0])
+	if ret != "250 2.0.0 Roger, accepting mail from <test@bla.de>\r\n" {
+		t.Errorf("Expected 250 2.0.0 Roger, accepting mail from <test@bla> got %s", ret)
+	}
+}
+
+func TestHandleNaturalFrom(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM:<Test Name <test@bla.de>>")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	if con.session.(*dummyBackend).mailFrom != "Test Name <test@bla.de>" {
+		t.Errorf("Expected test@bla.de, got %s", con.session.(*dummyBackend).mailFrom)
+	}
+	ret := string(tester.out[0])
+	if ret != "250 2.0.0 Roger, accepting mail from <Test Name <test@bla.de>>\r\n" {
+		t.Errorf("Expected 250 2.0.0 Roger, accepting mail from <test@bla> got %s", ret)
+	}
+}
+
+func TestHandleNaturalFromDefect(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM:<Test Name <test@bla.de>")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	if con.session.(*dummyBackend).mailFrom != "" {
+		t.Errorf("Expected '', got %s", con.session.(*dummyBackend).mailFrom)
+	}
+	ret := string(tester.out[0])
+	if ret != "501 5.5.2 Was expecting MAIL arg syntax of FROM:<address>\r\n" {
+		t.Errorf("Expected 501 5.5.2 Was expecting MAIL arg syntax of FROM:<address> got %s", ret)
+	}
+}
+
+func TestHandleEmptyFromOptions(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM: BODY=8BITMIME SIZE=12345")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	ret := string(tester.out[0])
+	if ret != "250 2.0.0 Roger, accepting mail from <BODY=8BITMIME>\r\n" {
+		t.Errorf("Expected 501 5.5.2 Was expecting MAIL arg syntax of FROM:<address>\r\n, got %s", ret)
+	}
+}
+
+func TestHandleSimpleFromOptions(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM:test@bla.de BODY=8BITMIME SIZE=12345")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	ret := string(tester.out[0])
+	if ret != "250 2.0.0 Roger, accepting mail from <test@bla.de>\r\n" {
+		t.Errorf("Expected 250 2.0.0 Roger, accepting mail from <test@bla> got %s", ret)
+	}
+	if con.session.(*dummyBackend).opts.Body != "8BITMIME" {
+		t.Errorf("Expected 8BITMIME, got %s", con.session.(*dummyBackend).opts.Body)
+	}
+	if con.session.(*dummyBackend).opts.Size != 12345 {
+		t.Errorf("Expected 12345, got %d", con.session.(*dummyBackend).opts.Size)
+	}
+	if con.session.(*dummyBackend).mailFrom != "test@bla.de" {
+		t.Errorf("Expected test@bla.de, got %s", con.session.(*dummyBackend).mailFrom)
+	}
+}
+
+func TestHandleSimpleSharpFromOptions(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM:<test@bla.de> BODY=8BITMIME SIZE=12345")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	if con.session.(*dummyBackend).opts.Body != "8BITMIME" {
+		t.Errorf("Expected 8BITMIME, got %s", con.session.(*dummyBackend).opts.Body)
+	}
+	if con.session.(*dummyBackend).opts.Size != 12345 {
+		t.Errorf("Expected 12345, got %d", con.session.(*dummyBackend).opts.Size)
+	}
+	if con.session.(*dummyBackend).mailFrom != "test@bla.de" {
+		t.Errorf("Expected test@bla.de, got %s", con.session.(*dummyBackend).mailFrom)
+	}
+	ret := string(tester.out[0])
+	if ret != "250 2.0.0 Roger, accepting mail from <test@bla.de>\r\n" {
+		t.Errorf("Expected 250 2.0.0 Roger, accepting mail from <test@bla> got %s", ret)
+	}
+}
+
+func TestHandleNaturalFromOptions(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM:<Test Name <test@bla.de>>  BODY=8BITMIME SIZE=12345")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	if con.session.(*dummyBackend).opts.Body != "8BITMIME" {
+		t.Errorf("Expected 8BITMIME, got %s", con.session.(*dummyBackend).opts.Body)
+	}
+	if con.session.(*dummyBackend).opts.Size != 12345 {
+		t.Errorf("Expected 12345, got %d", con.session.(*dummyBackend).opts.Size)
+	}
+	if con.session.(*dummyBackend).mailFrom != "Test Name <test@bla.de>" {
+		t.Errorf("Expected test@bla.de, got %s", con.session.(*dummyBackend).mailFrom)
+	}
+	ret := string(tester.out[0])
+	if ret != "250 2.0.0 Roger, accepting mail from <Test Name <test@bla.de>>\r\n" {
+		t.Errorf("Expected 250 2.0.0 Roger, accepting mail from <test@bla> got %s", ret)
+	}
+}
+
+func TestHandleNaturalFromDefectOptions(t *testing.T) {
+	con, tester := newTestConn()
+	con.handleMail("FROM:<Test Name <test@bla.de> BODY=8BITMIME SIZE=12345")
+	if len(tester.out) != 1 {
+		t.Errorf("Expected 1 output, got %d", len(tester.out))
+	}
+	if con.session.(*dummyBackend).mailFrom != "" {
+		t.Errorf("Expected '', got %s", con.session.(*dummyBackend).mailFrom)
+	}
+	ret := string(tester.out[0])
+	if ret != "501 5.5.2 Was expecting MAIL arg syntax of FROM:<address>\r\n" {
+		t.Errorf("Expected 501 5.5.2 Was expecting MAIL arg syntax of FROM:<address> got %s", ret)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -39,6 +39,7 @@ type Server struct {
 	LMTP bool
 
 	Domain            string
+	Name              string
 	MaxRecipients     int
 	MaxMessageBytes   int
 	MaxLineLength     int


### PR DESCRIPTION
I missed the possiblity to configure the Server Greeting after HELO

is was: Sprintf("220 %v ESMTP Service Ready", srv.Domain)

now you could set:

is was: Sprintf("220 %v ESMTP %s", srv.Domain, srv.Name)

the Name field is new.
