### PR TITLE
Fix sample server for v0.18.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ func (s *Session) Mail(from string, opts *smtp.MailOptions) error {
 	return nil
 }
 
-func (s *Session) Rcpt(to string) error {
+func (s *Session) Rcpt(to string, opts *smtp.RcptOptions) error {
 	if !s.auth {
 		return smtp.ErrAuthRequired
 	}


### PR DESCRIPTION
- Add `*smtp.RcptOptions` in session method `Rcpt()`.