### PR TITLE
Fix broken encodeXtext()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -426,16 +426,14 @@ func encodeXtext(raw string) string {
 	out.Grow(len(raw))
 
 	for _, ch := range raw {
-		if ch == '+' || ch == '=' {
+		switch {
+		case ch >= '!' && ch <= '~' && ch != '+' && ch != '=':
+			// printable non-space US-ASCII except '+' and '='
+			out.WriteRune(ch)
+		default:
 			out.WriteRune('+')
 			out.WriteString(strings.ToUpper(strconv.FormatInt(int64(ch), 16)))
 		}
-		if ch > '!' && ch < '~' { // printable non-space US-ASCII
-			out.WriteRune(ch)
-		}
-		// Non-ASCII.
-		out.WriteRune('+')
-		out.WriteString(strings.ToUpper(strconv.FormatInt(int64(ch), 16)))
 	}
 	return out.String()
 }


### PR DESCRIPTION
With this method call:
```go
email := "e=mc2@example.com"
c.Mail(email, &MailOptions{Auth: &email})
```
this should be sent to the server:
```
MAIL FROM:<e=mc2@example.com> AUTH=e+3Dmc2@example.com
```

However, following thing is sent:
```
MAIL FROM:<e=mc2@example.com> AUTH=e+65+3D=+3Dm+6Dc+632+32@+40e+65x+78a+61m+6Dp+70l+6Ce+65.+2Ec+63o+6Fm+6D
```
This PR will fix it.