### PR TITLE
 Support pre-SMTP connection rejection

### DIFF
--- a/server.go
+++ b/server.go
@@ -22,7 +22,7 @@ var (
 // A function that creates SASL servers.
 type SaslServerFactory func(conn *Conn) sasl.Server
 
-// A function that
+// A function that checks if a connection should be allowed.
 type AllowConnFunc func(conn *Conn) bool
 
 // Logger interface is used by Server to report unexpected internal errors.

--- a/server_test.go
+++ b/server_test.go
@@ -1155,6 +1155,21 @@ func TestServer_TooLongCommand(t *testing.T) {
 	}
 }
 
+func TestServer_ConnNotAllowed(t *testing.T) {
+	_, s, c, scanner := testServer(t, func(s *smtp.Server) {
+		s.AllowConn = func(conn *smtp.Conn) bool {
+			return false
+		}
+	})
+	defer s.Close()
+	defer c.Close()
+
+	ok := scanner.Scan()
+	if ok {
+		t.Fatal("Server should reject connection")
+	}
+}
+
 func TestServerShutdown(t *testing.T) {
 	_, s, c, _ := testServerGreeted(t)
 


### PR DESCRIPTION
This pull request adds the capability to reject connections to the server before any SMTP communication takes place. The primary motivation behind this feature is to provide control over incoming connections, allowing us to restrict access to our SMTP server to only specific IP ranges (in our use case, the IP ranges will be fetched dynamically from a remote source) 