### PR TITLE
Fix Conn.Hostname being empty when NewSession is called

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -227,9 +227,14 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 		c.writeResponse(501, EnhancedCode{5, 5, 2}, "Domain/address argument required for HELO")
 		return
 	}
+	// c.helo is populated before NewSession so
+	// NewSession can access it via Conn.Hostname.
+	c.helo = domain
 
 	sess, err := c.server.Backend.NewSession(c)
 	if err != nil {
+		c.helo = ""
+
 		if smtpErr, ok := err.(*SMTPError); ok {
 			c.writeResponse(smtpErr.Code, smtpErr.EnhancedCode, smtpErr.Message)
 			return
@@ -238,7 +243,6 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 		return
 	}
 
-	c.helo = domain
 	c.setSession(sess)
 
 	if !enhanced {


### PR DESCRIPTION
Conn.Hostname is the only way hostname can be read in NewSession. https://github.com/emersion/go-smtp/commit/d62ec8c7d00892343e81b21ad4fb33bcb7a900bb breaks this by setting it _after_ NewSession.

