### PR TITLE
Parse DATA\r\n\r\n.\r\n as \r\n\r\n message

### DIFF
--- a/data.go
+++ b/data.go
@@ -106,6 +106,10 @@ func (r *dataReader) Read(b []byte) (n int, err error) {
 				r.state = stateDot
 				continue
 			}
+			if c == '\r' {
+				r.state = stateCR
+				break
+			}
 			r.state = stateData
 		case stateDot:
 			if c == '\r' {


### PR DESCRIPTION
Note that this case is not exactly "no mail data" case referenced in RFC 5321. It is a message containing two empty lines (not one). FWIW This is what go-smtp client send if data writer is closed without writing to it - not sure where extra CRLF comes from.