### PR TITLE
server: replace EnableAuth with AuthSession

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -2,6 +2,8 @@ package smtp
 
 import (
 	"io"
+
+	"github.com/emersion/go-sasl"
 )
 
 var (
@@ -19,6 +21,11 @@ var (
 		Code:         502,
 		EnhancedCode: EnhancedCode{5, 7, 0},
 		Message:      "Authentication not supported",
+	}
+	ErrAuthUnknownMechanism = &SMTPError{
+		Code:         504,
+		EnhancedCode: EnhancedCode{5, 7, 4},
+		Message:      "Unsupported authentication mechanism",
 	}
 )
 
@@ -86,4 +93,13 @@ type LMTPSession interface {
 // information.
 type StatusCollector interface {
 	SetStatus(rcptTo string, err error)
+}
+
+// AuthSession is an add-on interface for Session. It provides support for the
+// AUTH extension.
+type AuthSession interface {
+	Session
+
+	AuthMechanisms() []string
+	Auth(mech string) (sasl.Server, error)
 }

--- a/server.go
+++ b/server.go
@@ -10,16 +10,11 @@ import (
 	"os"
 	"sync"
 	"time"
-
-	"github.com/emersion/go-sasl"
 )
 
 var (
 	ErrServerClosed = errors.New("smtp: server already closed")
 )
-
-// A function that creates SASL servers.
-type SaslServerFactory func(conn *Conn) sasl.Server
 
 // Logger interface is used by Server to report unexpected internal errors.
 type Logger interface {
@@ -71,10 +66,8 @@ type Server struct {
 	// The server backend.
 	Backend Backend
 
-	wg sync.WaitGroup
-
-	auths map[string]SaslServerFactory
-	done  chan struct{}
+	wg   sync.WaitGroup
+	done chan struct{}
 
 	locker    sync.Mutex
 	listeners []net.Listener
@@ -90,23 +83,7 @@ func NewServer(be Backend) *Server {
 		Backend:  be,
 		done:     make(chan struct{}, 1),
 		ErrorLog: log.New(os.Stderr, "smtp/server ", log.LstdFlags),
-		auths: map[string]SaslServerFactory{
-			sasl.Plain: func(conn *Conn) sasl.Server {
-				return sasl.NewPlainServer(func(identity, username, password string) error {
-					if identity != "" && identity != username {
-						return errors.New("identities not supported")
-					}
-
-					sess := conn.Session()
-					if sess == nil {
-						panic("No session when AUTH is called")
-					}
-
-					return sess.AuthPlain(username, password)
-				})
-			},
-		},
-		conns: make(map[*Conn]struct{}),
+		conns:    make(map[*Conn]struct{}),
 	}
 }
 
@@ -326,12 +303,4 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	case <-connDone:
 		return err
 	}
-}
-
-// EnableAuth enables an authentication mechanism on this server.
-//
-// This function should not be called directly, it must only be used by
-// libraries implementing extensions of the SMTP protocol.
-func (s *Server) EnableAuth(name string, f SaslServerFactory) {
-	s.auths[name] = f
 }


### PR DESCRIPTION
Closes: https://github.com/emersion/go-smtp/issues/170

Future work:

- Drop `Session.AuthPlain`
- Drop `Server.AuthDisabled`