### PR TITLE
Server: The value of BODY parameter is case-insensitive

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -344,16 +344,18 @@ func (c *Conn) handleMail(arg string) {
 			}
 			opts.RequireTLS = true
 		case "BODY":
-			switch value {
-			case "BINARYMIME":
+			value = strings.ToUpper(value)
+			switch BodyType(value) {
+			case BodyBinaryMIME:
 				if !c.server.EnableBINARYMIME {
 					c.writeResponse(504, EnhancedCode{5, 5, 4}, "BINARYMIME is not implemented")
 					return
 				}
 				c.binarymime = true
-			case "7BIT", "8BITMIME":
+			case Body7Bit, Body8BitMIME:
+				// This space is intentionally left blank
 			default:
-				c.writeResponse(500, EnhancedCode{5, 5, 4}, "Unknown BODY value")
+				c.writeResponse(501, EnhancedCode{5, 5, 4}, "Unknown BODY value")
 				return
 			}
 			opts.Body = BodyType(value)

--- a/server_test.go
+++ b/server_test.go
@@ -468,7 +468,7 @@ func TestServer8BITMIME(t *testing.T) {
 	defer s.Close()
 	defer c.Close()
 
-	io.WriteString(c, "MAIL FROM:<alice@wonderland.book> BODY=8BITMIME\r\n")
+	io.WriteString(c, "MAIL FROM:<alice@wonderland.book> BODY=8bitMIME\r\n")
 	scanner.Scan()
 	if !strings.HasPrefix(scanner.Text(), "250 ") {
 		t.Fatal("Invalid MAIL response:", scanner.Text())


### PR DESCRIPTION
Currently,
```code
MAIL FROM:<alice@wonderland.book> BODY=8bitMIME
```
is responded by `500 5.5.4 Unknown BODY value`.

This PR fixes it to make the parameter value case-insensitive.

___
In this occasion, it also makes status code for invalid parameter value `501` as RFC describes.
