### PR TITLE
Fix anonymous authentication with empty trace information string

### DIFF
--- a/client.go
+++ b/client.go
@@ -356,8 +356,13 @@ func (c *Client) Auth(a sasl.Client) error {
 	if err != nil {
 		return err
 	}
-	resp64 := make([]byte, encoding.EncodedLen(len(resp)))
-	encoding.Encode(resp64, resp)
+	var resp64 []byte
+	if len(resp) > 0 {
+		resp64 = make([]byte, encoding.EncodedLen(len(resp)))
+		encoding.Encode(resp64, resp)
+	} else if resp != nil {
+		resp64 = []byte{'='}
+	}
 	code, msg64, err := c.cmd(0, strings.TrimSpace(fmt.Sprintf("AUTH %s %s", mech, resp64)))
 	for err == nil {
 		var msg []byte

--- a/conn.go
+++ b/conn.go
@@ -773,11 +773,15 @@ func (c *Conn) handleAuth(arg string) {
 	// Parse client initial response if there is one
 	var ir []byte
 	if len(parts) > 1 {
-		var err error
-		ir, err = base64.StdEncoding.DecodeString(parts[1])
-		if err != nil {
-			c.writeResponse(454, EnhancedCode{4, 7, 0}, "Invalid base64 data")
-			return
+		if parts[1] == "=" {
+			ir = []byte{}
+		} else {
+			var err error
+			ir, err = base64.StdEncoding.DecodeString(parts[1])
+			if err != nil {
+				c.writeResponse(454, EnhancedCode{4, 7, 0}, "Invalid base64 data")
+				return
+			}
 		}
 	}
 
@@ -816,10 +820,14 @@ func (c *Conn) handleAuth(arg string) {
 			return
 		}
 
-		response, err = base64.StdEncoding.DecodeString(encoded)
-		if err != nil {
-			c.writeResponse(454, EnhancedCode{4, 7, 0}, "Invalid base64 data")
-			return
+		if encoded == "=" {
+			response = []byte{}
+		} else {
+			response, err = base64.StdEncoding.DecodeString(encoded)
+			if err != nil {
+				c.writeResponse(454, EnhancedCode{4, 7, 0}, "Invalid base64 data")
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
With anonymous authentication according to RFC4505 the trace information string is optional, and SMTP authentication extension described in RFC4954 states that:

    If the client is transmitting an initial response of zero
    length, it MUST instead transmit the response as a single
    equals sign ("=").  This indicates that the response is
    present, but contains no data.

Fixes #258