### PR TITLE
Add remote addr in error handler log

### DIFF
--- a/server.go
+++ b/server.go
@@ -120,7 +120,7 @@ func (s *Server) Serve(l net.Listener) error {
 
 			err := s.handleConn(newConn(c, s))
 			if err != nil {
-				s.ErrorLog.Printf("handler error: %s", err)
+				s.ErrorLog.Printf("error handling %v: %s", c.RemoteAddr(), err)
 			}
 		}()
 	}


### PR DESCRIPTION
When an incoming connection is not working, e.g. due to a missing proxy protocol header, there is currently no chance to catch details on server side, e.g. to debug where it came from.

This PR adds the remote address to the log line, making it more consistent with other logs like `panic serving %v: %s...`

Another solution might be to pass the connection as first parameter to the logger interface functions, but it's a heavier change and it might not work for situations where the connection could not be established at all.
