### PR TITLE
Allow manual Hello after StartTLS

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -653,6 +653,10 @@ func TestTLSConnState(t *testing.T) {
 			return
 		}
 		defer c.Quit()
+		if err := c.Hello("localhost"); err != nil {
+			t.Errorf("Client hello: %v", err)
+			return
+		}
 		cs, ok := c.TLSConnectionState()
 		if !ok {
 			t.Errorf("TLSConnectionState returned ok == false; want true")


### PR DESCRIPTION
Resolves https://github.com/emersion/go-smtp/issues/245

Also fixes possible problem with sending only `elho` after `StartTLS` ignoring `helo`