### PR TITLE
XOORG Server Support

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -276,6 +276,9 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 	if c.server.EnableDSN {
 		caps = append(caps, "DSN")
 	}
+	if c.server.EnableXOORG {
+		caps = append(caps, "XOORG")
+	}
 	if c.server.MaxMessageBytes > 0 {
 		caps = append(caps, fmt.Sprintf("SIZE %v", c.server.MaxMessageBytes))
 	} else {
@@ -339,6 +342,12 @@ func (c *Conn) handleMail(arg string) {
 			}
 
 			opts.Size = int64(size)
+		case "XOORG":
+			if !c.server.EnableXOORG {
+				c.writeResponse(504, EnhancedCode{5, 5, 4}, "EnableXOORG is not implemented")
+				return
+			}
+			opts.XOORG = value
 		case "SMTPUTF8":
 			if !c.server.EnableSMTPUTF8 {
 				c.writeResponse(504, EnhancedCode{5, 5, 4}, "SMTPUTF8 is not implemented")

--- a/server.go
+++ b/server.go
@@ -57,6 +57,10 @@ type Server struct {
 	// Should be used only if backend supports it.
 	EnableDSN bool
 
+	// Advertise XOORG capability.
+	// Should be used only if backend supports it.
+	EnableXOORG bool
+
 	// The server backend.
 	Backend Backend
 

--- a/smtp.go
+++ b/smtp.go
@@ -56,6 +56,9 @@ type MailOptions struct {
 	// Envelope identifier set by the client.
 	EnvelopeID string
 
+	// Accepted Domain from Exchange Online, e.g. from OutgoingConnector
+	XOORG string
+
 	// The authorization identity asserted by the message sender in decoded
 	// form with angle brackets stripped.
 	//


### PR DESCRIPTION
These changes allows the smtp server to advertise XOORG capability and extract it into the options. There is a simple test case added and it is tested against Exchange Online with a Outgoing Connector.

Some information about XOORG and it's usages:
https://techcommunity.microsoft.com/t5/exchange-team-blog/advanced-office-365-routing-locking-down-exchange-on-premises/ba-p/609238

I will also add XOORG client support next week, to be able to use it in combination with a Exchange Online Inbound Connector.