### PR TITLE
Add a status hook

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1244,6 +1244,9 @@ func (c *Conn) writeResponse(code int, enhCode EnhancedCode, text ...string) {
 	} else {
 		c.text.PrintfLine("%d %v.%v.%v %v", code, enhCode[0], enhCode[1], enhCode[2], text[len(text)-1])
 	}
+	if c.server.StatusLog != nil {
+		c.server.StatusLog.LogCode(code, enhCode, text...)
+	}
 }
 
 func (c *Conn) writeError(code int, enhCode EnhancedCode, err error) {

--- a/server.go
+++ b/server.go
@@ -1,3 +1,5 @@
+// Package smtp implements the base structs and functions for SMTP
+// servers and clients.
 package smtp
 
 import (
@@ -12,6 +14,7 @@ import (
 	"time"
 )
 
+// ErrServerClosed reports a server closed error.
 var ErrServerClosed = errors.New("smtp: server already closed")
 
 // Logger interface is used by Server to report unexpected internal errors.
@@ -20,7 +23,12 @@ type Logger interface {
 	Println(v ...interface{})
 }
 
-// A SMTP server.
+// StatusLogger interface is used by Server to report status codes.
+type StatusLogger interface {
+	LogCode(code int, enhCode EnhancedCode, text ...string)
+}
+
+// Server is the base struct for an SMTP server.
 type Server struct {
 	// The type of network, "tcp" or "unix".
 	Network string
@@ -38,6 +46,7 @@ type Server struct {
 	AllowInsecureAuth bool
 	Debug             io.Writer
 	ErrorLog          Logger
+	StatusLog         StatusLogger
 	ReadTimeout       time.Duration
 	WriteTimeout      time.Duration
 


### PR DESCRIPTION
Run a function when sending an SMTP status code.  Use for logging, metrics, debugging, etc.

I'm specifically doing this because I want to export out counts of SMTP server status and extended status codes as prometheus metrics. Folks could use it for other things as well - logging, other metrics systems, etc.