### PR TITLE
implement help

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -107,7 +107,7 @@ func (c *Conn) handle(cmd string, arg string) {
 
 	cmd = strings.ToUpper(cmd)
 	switch cmd {
-	case "SEND", "SOML", "SAML", "EXPN", "HELP", "TURN":
+	case "SEND", "SOML", "SAML", "EXPN", "TURN":
 		// These commands are not implemented in any state
 		c.writeResponse(502, EnhancedCode{5, 5, 1}, fmt.Sprintf("%v command not implemented", cmd))
 	case "HELO", "EHLO", "LHLO":
@@ -144,6 +144,8 @@ func (c *Conn) handle(cmd string, arg string) {
 		c.handleAuth(arg)
 	case "STARTTLS":
 		c.handleStartTLS()
+	case "HELP":
+		c.writeResponse(214, EnhancedCode{2, 0, 0}, "By helping others, you help yourself")
 	default:
 		msg := fmt.Sprintf("Syntax errors, %v command unrecognized", cmd)
 		c.protocolError(500, EnhancedCode{5, 5, 2}, msg)

--- a/server_test.go
+++ b/server_test.go
@@ -726,7 +726,7 @@ func TestServer_otherCommands(t *testing.T) {
 
 	io.WriteString(c, "HELP\r\n")
 	scanner.Scan()
-	if !strings.HasPrefix(scanner.Text(), "502 ") {
+	if !strings.HasPrefix(scanner.Text(), "214 ") {
 		t.Fatal("Invalid HELP response:", scanner.Text())
 	}
 


### PR DESCRIPTION
#264

Sendmail displays the version number and then has comprehensive help designed by topic. [chasquid](https://github.com/albertito/chasquid/blob/a1b6821ce12acbaed40c902763b715cf7f691666/internal/smtpsrv/conn.go#L396) Returns 214, 2.0.0 Hoy por ti, mañana por mi google translates to "Today I help you, tomorrow someone will help me."