### PR TITLE
server: handle newline characters in error messages

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1236,13 +1236,17 @@ func (c *Conn) writeResponse(code int, enhCode EnhancedCode, text ...string) {
 		}
 	}
 
-	for i := 0; i < len(text)-1; i++ {
+	// transform each single line with \n, into seperate lines
+	text = strings.Split(strings.Join(text, "\n"), "\n")
+
+	textLen := len(text) - 1
+	for i := 0; i < textLen; i++ {
 		c.text.PrintfLine("%d-%v", code, text[i])
 	}
 	if enhCode == NoEnhancedCode {
-		c.text.PrintfLine("%d %v", code, text[len(text)-1])
+		c.text.PrintfLine("%d %v", code, text[textLen])
 	} else {
-		c.text.PrintfLine("%d %v.%v.%v %v", code, enhCode[0], enhCode[1], enhCode[2], text[len(text)-1])
+		c.text.PrintfLine("%d %v.%v.%v %v", code, enhCode[0], enhCode[1], enhCode[2], text[textLen])
 	}
 }
 

--- a/conn.go
+++ b/conn.go
@@ -1236,7 +1236,7 @@ func (c *Conn) writeResponse(code int, enhCode EnhancedCode, text ...string) {
 		}
 	}
 
-	// transform each single line with \n, into seperate lines
+	// transform each single line with \n, into separate lines
 	text = strings.Split(strings.Join(text, "\n"), "\n")
 
 	textLen := len(text) - 1

--- a/conn.go
+++ b/conn.go
@@ -1239,14 +1239,14 @@ func (c *Conn) writeResponse(code int, enhCode EnhancedCode, text ...string) {
 	// transform each single line with \n, into separate lines
 	text = strings.Split(strings.Join(text, "\n"), "\n")
 
-	textLen := len(text) - 1
-	for i := 0; i < textLen; i++ {
+	lastLineIndex := len(text) - 1
+	for i := 0; i < lastLineIndex; i++ {
 		c.text.PrintfLine("%d-%v", code, text[i])
 	}
 	if enhCode == NoEnhancedCode {
-		c.text.PrintfLine("%d %v", code, text[textLen])
+		c.text.PrintfLine("%d %v", code, text[lastLineIndex])
 	} else {
-		c.text.PrintfLine("%d %v.%v.%v %v", code, enhCode[0], enhCode[1], enhCode[2], text[textLen])
+		c.text.PrintfLine("%d %v.%v.%v %v", code, enhCode[0], enhCode[1], enhCode[2], text[lastLineIndex])
 	}
 }
 


### PR DESCRIPTION
This very simple pr allows multi line error messages delimited with \n, per Issue #275.