### PR TITLE
Fix noisy error logging for zero-byte connections

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -41,9 +41,10 @@ type Conn struct {
 	dataResult      chan error
 	bytesReceived   int64 // counts total size of chunks when BDAT is used
 
-	fromReceived bool
-	recipients   []string
-	didAuth      bool
+	fromReceived    bool
+	recipients      []string
+	didAuth         bool
+	hasReceivedData bool // tracks if connection has sent any SMTP data
 }
 
 func newConn(c net.Conn, s *Server) *Conn {
@@ -1305,7 +1306,11 @@ func (c *Conn) readLine() (string, error) {
 		}
 	}
 
-	return c.text.ReadLine()
+	line, err := c.text.ReadLine()
+	if err == nil {
+		c.hasReceivedData = true // Mark that connection sent data
+	}
+	return line, err
 }
 
 func (c *Conn) reset() {

--- a/server.go
+++ b/server.go
@@ -131,8 +131,9 @@ func (s *Server) Serve(l net.Listener) error {
 		go func() {
 			defer s.wg.Done()
 
-			err := s.handleConn(newConn(c, s))
-			if err != nil {
+			conn := newConn(c, s)
+			err := s.handleConn(conn)
+			if err != nil && conn.hasReceivedData {
 				s.ErrorLog.Printf("error handling %v: %s", c.RemoteAddr(), err)
 			}
 		}()


### PR DESCRIPTION
Health checks connect and immediately disconnect without sending any data, this creates noisy logs.

This PR fixes it by only logging errors for connections that actually tried to send SMTP commands. Health checks that send nothing are now silent.

**What changed:**
- Track whether a connection sent any data 
- Skip error logging for zero-byte connections
- Real SMTP errors still get logged normally 

Includes a test that proves health checks no longer spam the logs.