### PR TITLE
Remove superfluous validateLine() calls in sendMail()

### DIFF
--- a/client.go
+++ b/client.go
@@ -499,7 +499,7 @@ func (c *Client) Rcpt(to string, opts *RcptOptions) error {
 	sb.Grow(2048)
 	fmt.Fprintf(&sb, "RCPT TO:<%s>", to)
 	if _, ok := c.ext["DSN"]; ok && opts != nil {
-		if opts.Notify != nil && len(opts.Notify) != 0 {
+		if len(opts.Notify) != 0 {
 			sb.WriteString(" NOTIFY=")
 			if err := checkNotifySet(opts.Notify); err != nil {
 				return errors.New("smtp: Malformed NOTIFY parameter value")
@@ -744,15 +744,6 @@ func (c *Client) SendMail(from string, to []string, r io.Reader) error {
 var testHookStartTLS func(*tls.Config) // nil, except for tests
 
 func sendMail(addr string, implicitTLS bool, a sasl.Client, from string, to []string, r io.Reader) error {
-	if err := validateLine(from); err != nil {
-		return err
-	}
-	for _, recp := range to {
-		if err := validateLine(recp); err != nil {
-			return err
-		}
-	}
-
 	var (
 		c   *Client
 		err error


### PR DESCRIPTION
Client.SendMail() already calls validateLine() via Client.Mail() and Client.Rcpt(), so there is no need to have these checks in sendMail().

Having these checks don't hurt as such, but looking at just the sendMail() function it's not obvious whether these checks are needed if you want to implement your own SendMail()-type function. With this change, you can copy/paste sendMail(), add the smtp. package selector, and modify as needed.

Also removes a superfluous nil check as a bonus.