### PR TITLE
Variablize response codes

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1261,7 +1261,7 @@ func dataErrorToStatus(err error) (code CodePair, msg string) {
 		if smtperr, ok := err.(*SMTPError); ok {
 			return CodePair{smtperr.Code, smtperr.EnhancedCode}, smtperr.Message
 		} else {
-			return CodePair{554, EnhancedCode{5, 0, 0}}, "Error: transaction failed: " + err.Error()
+			return CodeTransactionFailed, "Error: transaction failed: " + err.Error()
 		}
 	}
 	return CodeOk, "OK: queued"
@@ -1331,9 +1331,9 @@ func (c *Conn) writeResponseLines(codePair CodePair, lines ...string) {
 
 func (c *Conn) writeError(code CodePair, err error) {
 	if smtpErr, ok := err.(*SMTPError); ok {
-		c.writeResponse(CodePair{smtpErr.Code, smtpErr.EnhancedCode}, smtpErr.Message)
+		c.writeResponseLines(CodePair{smtpErr.Code, smtpErr.EnhancedCode}, smtpErr.Message)
 	} else {
-		c.writeResponse(code, err.Error())
+		c.writeResponseLines(code, err.Error())
 	}
 }
 

--- a/conn.go
+++ b/conn.go
@@ -92,7 +92,7 @@ func (c *Conn) handle(cmd string, arg string) {
 	// and close connection.
 	defer func() {
 		if err := recover(); err != nil {
-			c.writeResponse(CodeInternalErr, "Internal server error")
+			c.writeResponse(CodeNotAvailable, "Internal server error")
 			c.Close()
 
 			stack := debug.Stack()
@@ -880,7 +880,7 @@ func (c *Conn) handleAuth(arg string) {
 
 		if encoded == "*" {
 			// https://tools.ietf.org/html/rfc4954#page-4
-			c.writeResponse(CodeNegotiationCancelled, "Negotiation cancelled")
+			c.writeResponse(CodePair{501, EnhancedCode{5, 0, 0}}, "Negotiation cancelled")
 			return
 		}
 

--- a/data.go
+++ b/data.go
@@ -60,11 +60,12 @@ var (
 	CodeTooBusy              CodePair = CodePair{421, EnhancedCode{4, 4, 5}}
 	CodeActionAborted        CodePair = CodePair{451, EnhancedCode{4, 0, 0}}
 	CodeTooManyRcpts         CodePair = CodePair{452, EnhancedCode{4, 5, 3}}
-	CodeLineTooLong          CodePair = CodePair{500, EnhancedCode{5, 4, 0}}
-	CodeMsgTooBig            CodePair = CodePair{552, EnhancedCode{5, 3, 4}}
 	CodeIdleTimeout          CodePair = CodePair{421, EnhancedCode{4, 4, 2}}
 	CodeConnectionErr        CodePair = CodePair{421, EnhancedCode{4, 4, 0}}
+	CodeLineTooLong          CodePair = CodePair{500, EnhancedCode{5, 4, 0}}
 	CodeNegotiationCancelled CodePair = CodePair{501, EnhancedCode{5, 0, 0}}
+	CodeMsgTooBig            CodePair = CodePair{552, EnhancedCode{5, 3, 4}}
+	CodeTransactionFailed    CodePair = CodePair{554, EnhancedCode{5, 0, 0}}
 
 	CodeAuthSuccess   CodePair = CodePair{235, EnhancedCode{2, 7, 0}}
 	CodeAuthFail      CodePair = CodePair{454, EnhancedCode{4, 7, 0}}

--- a/data.go
+++ b/data.go
@@ -51,21 +51,20 @@ func (c *CodePair) populateEnhancedCode() {
 }
 
 var (
-	CodeReady                CodePair = CodePair{220, NoEnhancedCode}
-	CodeBye                  CodePair = CodePair{221, EnhancedCode{2, 0, 0}}
-	CodeOk                   CodePair = CodePair{250, EnhancedCode{2, 0, 0}}
-	CodeCannotVerifyUser     CodePair = CodePair{252, EnhancedCode{2, 5, 0}}
-	CodeStartMail            CodePair = CodePair{354, NoEnhancedCode}
-	CodeInternalErr          CodePair = CodePair{421, EnhancedCode{4, 0, 0}}
-	CodeTooBusy              CodePair = CodePair{421, EnhancedCode{4, 4, 5}}
-	CodeActionAborted        CodePair = CodePair{451, EnhancedCode{4, 0, 0}}
-	CodeTooManyRcpts         CodePair = CodePair{452, EnhancedCode{4, 5, 3}}
-	CodeIdleTimeout          CodePair = CodePair{421, EnhancedCode{4, 4, 2}}
-	CodeConnectionErr        CodePair = CodePair{421, EnhancedCode{4, 4, 0}}
-	CodeLineTooLong          CodePair = CodePair{500, EnhancedCode{5, 4, 0}}
-	CodeNegotiationCancelled CodePair = CodePair{501, EnhancedCode{5, 0, 0}}
-	CodeMsgTooBig            CodePair = CodePair{552, EnhancedCode{5, 3, 4}}
-	CodeTransactionFailed    CodePair = CodePair{554, EnhancedCode{5, 0, 0}}
+	CodeReady             CodePair = CodePair{220, NoEnhancedCode}
+	CodeBye               CodePair = CodePair{221, EnhancedCode{2, 0, 0}}
+	CodeOk                CodePair = CodePair{250, EnhancedCode{2, 0, 0}}
+	CodeCannotVerifyUser  CodePair = CodePair{252, EnhancedCode{2, 5, 0}}
+	CodeStartMail         CodePair = CodePair{354, NoEnhancedCode}
+	CodeNotAvailable      CodePair = CodePair{421, EnhancedCode{4, 0, 0}}
+	CodeTooBusy           CodePair = CodePair{421, EnhancedCode{4, 4, 5}}
+	CodeActionAborted     CodePair = CodePair{451, EnhancedCode{4, 0, 0}}
+	CodeTooManyRcpts      CodePair = CodePair{452, EnhancedCode{4, 5, 3}}
+	CodeBadConnection     CodePair = CodePair{421, EnhancedCode{4, 4, 2}}
+	CodeConnectionErr     CodePair = CodePair{421, EnhancedCode{4, 4, 0}}
+	CodeLineTooLong       CodePair = CodePair{500, EnhancedCode{5, 4, 0}}
+	CodeMsgTooBig         CodePair = CodePair{552, EnhancedCode{5, 3, 4}}
+	CodeTransactionFailed CodePair = CodePair{554, EnhancedCode{5, 0, 0}}
 
 	CodeAuthSuccess   CodePair = CodePair{235, EnhancedCode{2, 7, 0}}
 	CodeAuthFail      CodePair = CodePair{454, EnhancedCode{4, 7, 0}}

--- a/data.go
+++ b/data.go
@@ -29,6 +29,61 @@ var NoEnhancedCode = EnhancedCode{-1, -1, -1}
 // be used (X is derived from error code).
 var EnhancedCodeNotSet = EnhancedCode{0, 0, 0}
 
+// CodePair represents a combination of
+// a basic smtp code and an enhanced code.
+type CodePair struct {
+	Basic    int
+	Enhanced EnhancedCode
+}
+
+// Populates a generic enhanced code for code
+// pairs where enhanced code is not set.
+func (c *CodePair) populateEnhancedCode() {
+	if c.Enhanced == EnhancedCodeNotSet {
+		cat := c.Basic / 100
+		switch cat {
+		case 2, 4, 5:
+			c.Enhanced = EnhancedCode{cat, 0, 0}
+		default:
+			c.Enhanced = NoEnhancedCode
+		}
+	}
+}
+
+var (
+	CodeReady                CodePair = CodePair{220, NoEnhancedCode}
+	CodeBye                  CodePair = CodePair{221, EnhancedCode{2, 0, 0}}
+	CodeOk                   CodePair = CodePair{250, EnhancedCode{2, 0, 0}}
+	CodeCannotVerifyUser     CodePair = CodePair{252, EnhancedCode{2, 5, 0}}
+	CodeStartMail            CodePair = CodePair{354, NoEnhancedCode}
+	CodeInternalErr          CodePair = CodePair{421, EnhancedCode{4, 0, 0}}
+	CodeTooBusy              CodePair = CodePair{421, EnhancedCode{4, 4, 5}}
+	CodeActionAborted        CodePair = CodePair{451, EnhancedCode{4, 0, 0}}
+	CodeTooManyRcpts         CodePair = CodePair{452, EnhancedCode{4, 5, 3}}
+	CodeLineTooLong          CodePair = CodePair{500, EnhancedCode{5, 4, 0}}
+	CodeMsgTooBig            CodePair = CodePair{552, EnhancedCode{5, 3, 4}}
+	CodeIdleTimeout          CodePair = CodePair{421, EnhancedCode{4, 4, 2}}
+	CodeConnectionErr        CodePair = CodePair{421, EnhancedCode{4, 4, 0}}
+	CodeNegotiationCancelled CodePair = CodePair{501, EnhancedCode{5, 0, 0}}
+
+	CodeAuthSuccess   CodePair = CodePair{235, EnhancedCode{2, 7, 0}}
+	CodeAuthFail      CodePair = CodePair{454, EnhancedCode{4, 7, 0}}
+	CodeAuthChallenge CodePair = CodePair{334, NoEnhancedCode}
+
+	CodeInvalidCmd      CodePair = CodePair{500, EnhancedCode{5, 5, 1}}
+	CodeInvalidArg      CodePair = CodePair{501, EnhancedCode{5, 5, 4}}
+	CodeInvalidSequence CodePair = CodePair{503, EnhancedCode{5, 5, 1}}
+
+	CodeSyntaxErrCmd CodePair = CodePair{500, EnhancedCode{5, 5, 2}}
+	CodeSyntaxErrArg CodePair = CodePair{501, EnhancedCode{5, 5, 2}}
+
+	CodeNotImplementedCmd CodePair = CodePair{502, EnhancedCode{5, 5, 1}}
+	CodeNotImplementedArg CodePair = CodePair{504, EnhancedCode{5, 5, 4}}
+
+	CodeTlsRequired     CodePair = CodePair{523, EnhancedCode{5, 7, 10}}
+	CodeTlsHandshakeErr CodePair = CodePair{550, EnhancedCode{5, 0, 0}}
+)
+
 func (err *SMTPError) Error() string {
 	s := fmt.Sprintf("SMTP error %03d", err.Code)
 	if err.Message != "" {
@@ -42,8 +97,8 @@ func (err *SMTPError) Temporary() bool {
 }
 
 var ErrDataTooLarge = &SMTPError{
-	Code:         552,
-	EnhancedCode: EnhancedCode{5, 3, 4},
+	Code:         CodeMsgTooBig.Basic,
+	EnhancedCode: CodeMsgTooBig.Enhanced,
 	Message:      "Maximum message size exceeded",
 }
 

--- a/data.go
+++ b/data.go
@@ -57,18 +57,18 @@ var (
 	CodeCannotVerifyUser  CodePair = CodePair{252, EnhancedCode{2, 5, 0}}
 	CodeStartMail         CodePair = CodePair{354, NoEnhancedCode}
 	CodeNotAvailable      CodePair = CodePair{421, EnhancedCode{4, 0, 0}}
+	CodeConnectionErr     CodePair = CodePair{421, EnhancedCode{4, 4, 0}}
+	CodeBadConnection     CodePair = CodePair{421, EnhancedCode{4, 4, 2}}
 	CodeTooBusy           CodePair = CodePair{421, EnhancedCode{4, 4, 5}}
 	CodeActionAborted     CodePair = CodePair{451, EnhancedCode{4, 0, 0}}
 	CodeTooManyRcpts      CodePair = CodePair{452, EnhancedCode{4, 5, 3}}
-	CodeBadConnection     CodePair = CodePair{421, EnhancedCode{4, 4, 2}}
-	CodeConnectionErr     CodePair = CodePair{421, EnhancedCode{4, 4, 0}}
 	CodeLineTooLong       CodePair = CodePair{500, EnhancedCode{5, 4, 0}}
 	CodeMsgTooBig         CodePair = CodePair{552, EnhancedCode{5, 3, 4}}
 	CodeTransactionFailed CodePair = CodePair{554, EnhancedCode{5, 0, 0}}
 
 	CodeAuthSuccess   CodePair = CodePair{235, EnhancedCode{2, 7, 0}}
-	CodeAuthFail      CodePair = CodePair{454, EnhancedCode{4, 7, 0}}
 	CodeAuthChallenge CodePair = CodePair{334, NoEnhancedCode}
+	CodeAuthFail      CodePair = CodePair{454, EnhancedCode{4, 7, 0}}
 
 	CodeInvalidCmd      CodePair = CodePair{500, EnhancedCode{5, 5, 1}}
 	CodeInvalidArg      CodePair = CodePair{501, EnhancedCode{5, 5, 4}}

--- a/server.go
+++ b/server.go
@@ -180,7 +180,7 @@ func (s *Server) handleConn(c *Conn) error {
 		if err == nil {
 			cmd, arg, err := parseCmd(line)
 			if err != nil {
-				c.protocolError(501, EnhancedCode{5, 5, 2}, "Bad command")
+				c.protocolError(CodeSyntaxErrCmd, "Bad command")
 				continue
 			}
 
@@ -190,16 +190,16 @@ func (s *Server) handleConn(c *Conn) error {
 				return nil
 			}
 			if err == ErrTooLongLine {
-				c.writeResponse(500, EnhancedCode{5, 4, 0}, "Too long line, closing connection")
+				c.writeResponse(CodeLineTooLong, "Too long line, closing connection")
 				return nil
 			}
 
 			if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
-				c.writeResponse(421, EnhancedCode{4, 4, 2}, "Idle timeout, bye bye")
+				c.writeResponse(CodeIdleTimeout, "Idle timeout, bye bye")
 				return nil
 			}
 
-			c.writeResponse(421, EnhancedCode{4, 4, 0}, "Connection error, sorry")
+			c.writeResponse(CodeConnectionErr, "Connection error, sorry")
 			return err
 		}
 	}

--- a/server.go
+++ b/server.go
@@ -195,7 +195,7 @@ func (s *Server) handleConn(c *Conn) error {
 			}
 
 			if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
-				c.writeResponse(CodeIdleTimeout, "Idle timeout, bye bye")
+				c.writeResponse(CodeBadConnection, "Idle timeout, bye bye")
 				return nil
 			}
 

--- a/server_test.go
+++ b/server_test.go
@@ -921,14 +921,14 @@ func TestServer_authParam(t *testing.T) {
 	// Invalid HEXCHAR
 	io.WriteString(c, "MAIL FROM: root@nsa.gov AUTH=<hey+A>\r\n")
 	scanner.Scan()
-	if !strings.HasPrefix(scanner.Text(), "500 ") {
+	if !strings.HasPrefix(scanner.Text(), "501 ") {
 		t.Fatal("Invalid MAIL response:", scanner.Text())
 	}
 
 	// Invalid HEXCHAR
 	io.WriteString(c, "MAIL FROM: root@nsa.gov AUTH=<he+YYa>\r\n")
 	scanner.Scan()
-	if !strings.HasPrefix(scanner.Text(), "500 ") {
+	if !strings.HasPrefix(scanner.Text(), "501 ") {
 		t.Fatal("Invalid MAIL response:", scanner.Text())
 	}
 


### PR DESCRIPTION
- Move common response code pairs to variables to increase readability and expose them as part of the api.
- Separate writeResponse function for single line responses so that they don't unnecessarily call split/join.