### PR TITLE
Add support for postfix XFORWARD command.

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -63,6 +63,10 @@ type Session interface {
 	//
 	// r must be consumed before Data returns.
 	Data(r io.Reader) error
+
+	// XForward is called for any attribute name/value pair.
+	// See https://www.postfix.org/XFORWARD_README.html
+	XForward(attrName, attrValue string) error
 }
 
 // LMTPSession is an add-on interface for Session. It can be implemented by

--- a/cmd/smtp-debug-server/main.go
+++ b/cmd/smtp-debug-server/main.go
@@ -39,6 +39,10 @@ func (s *session) Data(r io.Reader) error {
 	return nil
 }
 
+func (s *session) XForward(attrName, attrValue string) error {
+	return nil
+}
+
 func (s *session) Reset() {}
 
 func (s *session) Logout() error {

--- a/example_server_test.go
+++ b/example_server_test.go
@@ -68,6 +68,11 @@ func (s *Session) Data(r io.Reader) error {
 	return nil
 }
 
+func (s *Session) XForward(attrName, attrValue string) error {
+	log.Printf("XFORWARD %s=%s\n", attrName, attrValue)
+	return nil
+}
+
 func (s *Session) Reset() {}
 
 func (s *Session) Logout() error {
@@ -99,6 +104,7 @@ func ExampleServer() {
 	s.MaxMessageBytes = 1024 * 1024
 	s.MaxRecipients = 50
 	s.AllowInsecureAuth = true
+	s.EnableXFORWARD = true
 
 	log.Println("Starting server at", s.Addr)
 	if err := s.ListenAndServe(); err != nil {

--- a/parse.go
+++ b/parse.go
@@ -22,6 +22,8 @@ func parseCmd(line string) (cmd string, arg string, err error) {
 	switch {
 	case strings.HasPrefix(strings.ToUpper(line), "STARTTLS"):
 		return "STARTTLS", "", nil
+	case strings.HasPrefix(strings.ToUpper(line), "XFORWARD"):
+		return "XFORWARD", strings.TrimSpace(line[8:]), nil
 	case l == 0:
 		return "", "", nil
 	case l < 4:

--- a/server.go
+++ b/server.go
@@ -73,6 +73,12 @@ type Server struct {
 	// Advertise MT-PRIORITY (RFC 6710) capability.
 	// Should only be used if backend supports it.
 	EnableMTPRIORITY bool
+
+	// Advertise XFORWARD NAME ADDR PROTO HELO
+	// (https://www.postfix.org/XFORWARD_README.html) capability.
+	// Should only be used if backend supports it.
+	EnableXFORWARD bool
+
 	// The priority profile mapping as defined
 	// in RFC 6710 section 10.2.
 	//


### PR DESCRIPTION
I have need of support, and would like to contribute back if it fits in. XFORWARD is not an RFC standard ([https://www.postfix.org/XFORWARD_README.html](https://www.postfix.org/XFORWARD_README.html)) , but it's used in postfix in more complicated proxy setups and content filters, and is _much_ more reliable than trying to partially read the DATA of a message to parse a Received header (also, I dont like adding those for intermediate servers). I've tried to match existing style as much as I could.

The downside? Adding the function to the session interface breaks existing code, requiring at minimum a noop function in consumers. I didn't see an easy way around this and it's very easy to add to release notes, but it is a breaking change to existing code, which is never nice.

There's probably some more room for improvement (e.g. the permitted attributes are not an exhaustive list here), but wanted to submit this as an early PR to gauge appetite for it - I've tested it as working in my application, and would be perfectly happy to merge as-is. Here are some examples from my system logging (everything on a local system):

```
HAVE XFORWARD NAME:[UNAVAILABLE]
HAVE XFORWARD ADDR:172.18.0.1
HAVE XFORWARD HELO:localhost.dev.mydomain.com
HAVE XFORWARD PROTO:ESMTP
```