### PR TITLE
allow custom serverName in client

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -119,7 +119,7 @@ func TestBasic(t *testing.T) {
 		t.Fatalf("Second VRFY: expected verification, got %s", err)
 	}
 
-	c.serverName = "smtp.google.com"
+	c.ServerName = "smtp.google.com"
 	if err := c.Auth(sasl.NewPlainClient("", "user", "pass")); err != nil {
 		t.Fatalf("AUTH failed: %s", err)
 	}
@@ -418,7 +418,7 @@ func TestHello(t *testing.T) {
 		fake.ReadWriter = bufio.NewReadWriter(bufio.NewReader(strings.NewReader(server)), bcmdbuf)
 		c := NewClient(fake)
 		defer c.Close()
-		c.serverName = "fake.host"
+		c.ServerName = "fake.host"
 		c.localName = "customhost"
 
 		var err error
@@ -437,7 +437,7 @@ func TestHello(t *testing.T) {
 		case 2:
 			err = c.Verify("test@example.com")
 		case 3:
-			c.serverName = "smtp.google.com"
+			c.ServerName = "smtp.google.com"
 			err = c.Auth(sasl.NewPlainClient("", "user", "pass"))
 		case 4:
 			err = c.Mail("test@example.com", nil)
@@ -525,7 +525,7 @@ func TestHello_421Response(t *testing.T) {
 	fake.ReadWriter = bufio.NewReadWriter(bufio.NewReader(strings.NewReader(server)), bcmdbuf)
 	c := NewClient(fake)
 	defer c.Close()
-	c.serverName = "fake.host"
+	c.ServerName = "fake.host"
 	c.localName = "customhost"
 
 	err := c.Hello("customhost")
@@ -579,7 +579,7 @@ func TestAuthFailed(t *testing.T) {
 	c := NewClient(fake)
 	defer c.Close()
 
-	c.serverName = "smtp.google.com"
+	c.ServerName = "smtp.google.com"
 	err := c.Auth(sasl.NewPlainClient("", "user", "pass"))
 
 	if err == nil {


### PR DESCRIPTION
In order to use a custom dialer with a different timeout for the SMTP client,
we need to be able set the client's serverName after calling `NewClient(conn)` or `NewClientStartTLS(conn, tlsConfig)`,
so that TLS server certificates can still be matched to the hostname.

Other solutions might be to
- Extend the `NewClient...()` calls by an `serverName string` argument (not backwards-compatible)
- Add a `func (c *Client) SetServerName(string)` method

I chose to make the `serverName` field public to minimize changes, be backwards-compatible and consistent with customizing other fields like the `CommandTimeout`.