### PR TITLE
Implemented dynamic domain support

### DIFF
--- a/server.go
+++ b/server.go
@@ -40,6 +40,7 @@ type Server struct {
 	ErrorLog          Logger
 	ReadTimeout       time.Duration
 	WriteTimeout      time.Duration
+	domainFn          func(*Conn) (string, error)
 
 	// Advertise SMTPUTF8 (RFC 6531) capability.
 	// Should be used only if backend supports it.
@@ -146,6 +147,19 @@ func (s *Server) Serve(l net.Listener) error {
 			}
 		}()
 	}
+}
+
+// Getter for the optional dynamic domain string generator function
+func (s *Server) GetDomain(c *Conn) (string, error) {
+	if s.domainFn != nil {
+		return s.domainFn(c)
+	}
+	return s.Domain, nil
+}
+
+// Setter for the dynamic domain string generator function
+func (s *Server) SetDomainFunc(fn func(*Conn) (string, error)) {
+	s.domainFn = fn
 }
 
 func (s *Server) handleConn(c *Conn) error {

--- a/server_test.go
+++ b/server_test.go
@@ -1797,4 +1797,10 @@ func TestServerNegativeDynamicDomainGreeted(t *testing.T) {
 	if !strings.HasPrefix(scanner.Text(), "503 bad sequence of commands") {
 		t.Fatal("Invalid HELO response:", scanner.Text())
 	}
+	io.WriteString(c, "QUIT\r\n")
+
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "221 OK") {
+		t.Fatal("Invalid HELO response:", scanner.Text())
+	}
 }


### PR DESCRIPTION
## What is this

Implemented dynamic domain support that also doubles as a health check endpoint for loadbalancers.
Details:

### Dynamic domain support
Traditionally `conn.Domain` contains the domain that should be the server identifying itself to the connecting clients with during the initial greeting. My PR enabled this field to be dynamic: a function can be specified to generate the value for this field instead of passing the `conn.Domain` value. It is backward compatible as the greeter will send the value of the `conn.Domain` field if the dynamic getter function is not set. This feature is useful if a given server handles traffic for more than one endpoint.

### Health check support
Greeter function will reject the connection with 554 if the dynamic function returns an error. This is very intentional and is particularly useful with load-balanced setups as in this case the server has an option to tell the health-check-monitoring loadbalancer if they are incapable of receiving traffic. The `Conn.handle` was also modified to be in conform with RFC5321 regarding proper handling of rejected sessions.

## Checkmarks

- [x] implementation
- [x] tests
- [ ] documentation: not found anything besides godoc.
