### PR TITLE
server: allow advertising extra EHLO capabilities

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -308,6 +308,7 @@ func (c *Conn) handleGreet(enhanced bool, arg string) {
 			caps = append(caps, fmt.Sprintf("MT-PRIORITY %s", c.server.MtPriorityProfile))
 		}
 	}
+	caps = append(caps, c.server.ExtraCaps...)
 
 	args := []string{"Hello " + domain}
 	args = append(args, caps...)

--- a/server.go
+++ b/server.go
@@ -79,6 +79,15 @@ type Server struct {
 	// Default value of NONE to advertise no specific profile.
 	MtPriorityProfile PriorityProfile
 
+	// Additional capabilities to advertise in response to EHLO, e.g.
+	// "XEXAMPLE https://example.org/smtp-ext". Each entry is advertised
+	// verbatim as a separate capability line.
+	//
+	// This can be used to advertise site-specific extensions that are not
+	// natively supported by this package. It is the caller's responsibility
+	// to handle any commands such an extension defines.
+	ExtraCaps []string
+
 	// The server backend.
 	Backend Backend
 

--- a/server_test.go
+++ b/server_test.go
@@ -355,6 +355,22 @@ func TestServer_helo(t *testing.T) {
 	}
 }
 
+func TestServerExtraCaps(t *testing.T) {
+	_, s, c, scanner, caps := testServerEhlo(t,
+		func(s *smtp.Server) {
+			s.ExtraCaps = []string{"XEXAMPLE https://example.org/smtp-ext"}
+		})
+	defer s.Close()
+	defer c.Close()
+
+	if _, ok := caps["XEXAMPLE https://example.org/smtp-ext"]; !ok {
+		t.Fatal("Missing extra capability in EHLO response")
+	}
+
+	io.WriteString(c, "QUIT\r\n")
+	scanner.Scan()
+}
+
 func testServerAuthenticated(t *testing.T) (be *backend, s *smtp.Server, c net.Conn, scanner *bufio.Scanner) {
 	be, s, c, scanner, caps := testServerEhlo(t)
 


### PR DESCRIPTION
This adds an `ExtraCaps` field to `Server` holding additional capability
lines to advertise in response to EHLO. Each entry is advertised verbatim
as a separate capability line, after the built-in capabilities:

    srv := smtp.NewServer(be)
    srv.ExtraCaps = []string{"XEXAMPLE https://example.org/smtp-ext"}

    C: EHLO client.example.org
    S: 250-mx.example.org Hello client.example.org
    S: ...
    S: 250 XEXAMPLE https://example.org/smtp-ext

Motivation: servers sometimes need to advertise site-specific extensions
that go-smtp cannot know about — in our case a discovery capability that
points peer servers at an HTTPS upgrade endpoint (`RESTMAIL
https://<host>/restmail`). Today the capability list is built entirely
inside `handleGreet` from hard-wired `Enable*` flags, so the only options
are forking or proxying the connection. A verbatim string slice is the
smallest hook that covers this: no callback, no per-connection state, and
zero overhead for servers that do not set it.

Handling any commands such an extension defines remains the caller's
responsibility (same contract as the existing `Enable*` flags, which only
control advertising).

Includes a test (`TestServerExtraCaps`) in the style of the existing
capability tests via `testServerEhlo`.
