### PR TITLE
server: restore line limit when a BDAT transaction is reset

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1341,6 +1341,9 @@ func (c *Conn) reset() {
 	c.bdatStatus = nil
 	c.bytesReceived = 0
 
+	// BDAT disables the line limit while reading a chunk, the transaction is over now.
+	c.lineLimitReader.LineLimit = c.server.MaxLineLength
+
 	if c.session != nil {
 		c.session.Reset()
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -1228,6 +1228,38 @@ func TestServer_Chunking_tooLongMessage(t *testing.T) {
 	}
 }
 
+func TestServer_Chunking_lineLimitRestoredAfterReset(t *testing.T) {
+	_, s, c, scanner := testServerAuthenticated(t)
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "MAIL FROM:<root@nsa.gov>\r\n")
+	scanner.Scan()
+	io.WriteString(c, "RCPT TO:<root@gchq.gov.uk>\r\n")
+	scanner.Scan()
+
+	io.WriteString(c, "BDAT 8\r\n")
+	io.WriteString(c, "Hey <3\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "250 ") {
+		t.Fatal("Invalid BDAT response:", scanner.Text())
+	}
+
+	// The client gives up on the message instead of sending the last chunk.
+	io.WriteString(c, "RSET\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "250 ") {
+		t.Fatal("Invalid RSET response:", scanner.Text())
+	}
+
+	// The transfer is over, so MaxLineLength should be enforced again.
+	io.WriteString(c, "NOOP "+strings.Repeat("x", s.MaxLineLength)+"\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "500 ") {
+		t.Fatal("Invalid response to an over-long line:", scanner.Text())
+	}
+}
+
 func TestServer_Chunking_Binarymime(t *testing.T) {
 	be, s, c, scanner := testServerAuthenticated(t)
 	defer s.Close()


### PR DESCRIPTION
Hit this on a server with CHUNKING on. If a client starts a BDAT transfer and then gives up with `RSET`, `MaxLineLength` never gets enforced again for the rest of that connection. Same story when a chunk trips `MaxMessageBytes`. Both of those end the transaction via `reset()`, which did not put the limit back.

Server left on the default `MaxLineLength` of 2000:

```
C: BDAT 8
C: Hey <3
S: 250 2.0.0 Continue
C: RSET
S: 250 2.0.0 Session reset
C: NOOP xxxxx... (2005 bytes)
S: 250 2.0.0 I have successfully done nothing
```

On a fresh connection that last line gets `500 5.4.0 Too long line, closing connection`.

The `io.Copy` failure path picked up a restore back in #139, these two go out through `reset()` instead. I have left both existing restores in `handleBdat` alone, the one before the LAST chunk still covers the `errPanic` return that skips `reset()`.