### PR TITLE
client: clear recipient list when a new transaction starts

### DIFF
--- a/client.go
+++ b/client.go
@@ -34,7 +34,7 @@ type Client struct {
 	greetError error             // the error from the greeting
 	didHello   bool              // whether we've said HELO/EHLO/LHLO
 	helloError error             // the error from the hello
-	rcpts      []string          // recipients accumulated for the current session
+	rcpts      []string          // recipients accumulated for the current transaction
 
 	// Time to wait for command responses (this includes 3xx reply to DATA).
 	CommandTimeout time.Duration
@@ -477,8 +477,14 @@ func (c *Client) Mail(from string, opts *MailOptions) error {
 		}
 		// We can safely discard parameter if server does not support AUTH.
 	}
-	_, _, err := c.cmd(250, "%s", sb.String())
-	return err
+	if _, _, err := c.cmd(250, "%s", sb.String()); err != nil {
+		return err
+	}
+
+	// A new transaction has started, forget the previous recipients.
+	c.rcpts = nil
+
+	return nil
 }
 
 // Rcpt issues a RCPT command to the server using the provided email address.

--- a/client_test.go
+++ b/client_test.go
@@ -1077,6 +1077,68 @@ Goodbye.`
 	}
 }
 
+func TestLMTPDataTwoMessages(t *testing.T) {
+	var lmtpServerTwoMessages = `220 localhost Simple Mail Transfer Service Ready
+250-localhost at your service
+250 8BITMIME
+250 Sender OK
+250 Receiver OK
+354 Go ahead
+250 First message OK
+250 Sender OK
+250 Receiver OK
+354 Go ahead
+250 Second message OK
+221 OK
+`
+	server := strings.Join(strings.Split(lmtpServerTwoMessages, "\n"), "\r\n")
+
+	var cmdbuf bytes.Buffer
+	bcmdbuf := bufio.NewWriter(&cmdbuf)
+	var fake faker
+	fake.ReadWriter = bufio.NewReadWriter(bufio.NewReader(strings.NewReader(server)), bcmdbuf)
+	c := &Client{text: textproto.NewConn(fake), conn: fake, lmtp: true}
+
+	if err := c.Hello("localhost"); err != nil {
+		t.Fatalf("LHLO failed: %s", err)
+	}
+	c.didHello = true
+
+	send := func(rcpt, statusText string) {
+		t.Helper()
+
+		if err := c.Mail("user@gmail.com", nil); err != nil {
+			t.Fatalf("MAIL failed: %s", err)
+		}
+		if err := c.Rcpt(rcpt, nil); err != nil {
+			t.Fatalf("RCPT failed: %s", err)
+		}
+		w, err := c.Data()
+		if err != nil {
+			t.Fatalf("DATA failed: %s", err)
+		}
+		if _, err := w.Write([]byte("Hello")); err != nil {
+			t.Fatalf("Data write failed: %s", err)
+		}
+		resp, err := w.CloseWithLMTPResponse()
+		if err != nil {
+			t.Fatalf("CloseWithLMTPResponse failed: %s", err)
+		}
+
+		wantResp := map[string]*DataResponse{rcpt: {StatusText: statusText}}
+		if !reflect.DeepEqual(resp, wantResp) {
+			t.Fatalf("resp = %v, want %v", resp, wantResp)
+		}
+	}
+
+	send("golang-nuts@googlegroups.com", "First message OK")
+	send("golang-not-nuts@googlegroups.com", "Second message OK")
+
+	if err := c.Quit(); err != nil {
+		t.Fatalf("QUIT failed: %s", err)
+	}
+}
+
 var xtextClient = `MAIL FROM:<e=mc2@example.com> AUTH=e+3Dmc2@example.com
 RCPT TO:<e=mc2@example.com> ORCPT=UTF-8;e\x{3D}mc2@example.com
 `


### PR DESCRIPTION
Sending a second message down the same LMTP connection just hangs. `CloseWithLMTPResponse` reads one reply per entry in `c.rcpts`, and nothing clears that slice when a new transaction starts, so the second message waits on two replies, gets one, then sits there untill `SubmissionTimeout` - 12 minutes by default. The one reply it does get is filed against the wrong recipient.

`Reset` does clear it, but it's documented as aborting the current transaction, so you wouldn't reach for it after a delivery that went fine.

Only the LMTP path reads the field so plain SMTP shoud be unaffected. I've run it against this repo's own server and the scripted test, not a real delivery agent.