### PR TITLE
server: consume the rest of an oversized message body in LMTP mode

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1215,6 +1215,7 @@ func (c *Conn) handleDataLMTP() {
 	if !ok {
 		// Fallback to using a single status for all recipients.
 		err := c.Session().Data(r)
+		r.limited = false
 		io.Copy(ioutil.Discard, r) // Make sure all the data has been consumed
 		for _, rcpt := range c.recipients {
 			status.SetStatus(rcpt, err)
@@ -1237,6 +1238,7 @@ func (c *Conn) handleDataLMTP() {
 			}()
 
 			status.fillRemaining(lmtpSession.LMTPData(r, status))
+			r.limited = false
 			io.Copy(ioutil.Discard, r) // Make sure all the data has been consumed
 			done <- true
 		}()

--- a/lmtp_server_test.go
+++ b/lmtp_server_test.go
@@ -86,6 +86,45 @@ func TestServer_LMTP(t *testing.T) {
 	}
 }
 
+func TestServer_LMTP_tooLongMessage(t *testing.T) {
+	be, s, c, scanner := testServerGreetedLMTP(t, func(s *smtp.Server) {
+		s.LMTP = true
+		s.MaxMessageBytes = 50
+	})
+	defer s.Close()
+	defer c.Close()
+
+	sendLHLO(t, scanner, c)
+	io.WriteString(c, "MAIL FROM:<root@nsa.gov>\r\n")
+	scanner.Scan()
+	io.WriteString(c, "RCPT TO:<root@gchq.gov.uk>\r\n")
+	scanner.Scan()
+	io.WriteString(c, "DATA\r\n")
+	scanner.Scan()
+
+	io.WriteString(c, "This is a very long message.\r\n")
+	io.WriteString(c, "Much longer than you can possibly imagine.\r\n")
+	io.WriteString(c, "MAIL FROM:<root@example.org>\r\n")
+	io.WriteString(c, ".\r\n")
+
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "552 ") {
+		t.Fatal("Invalid DATA response, expected an error but got:", scanner.Text())
+	}
+
+	// See that command stream state is not corrupted e.g. server is not
+	// interpreting the rest of the message body as commands.
+	io.WriteString(c, "NOOP\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "250 ") {
+		t.Fatal("Invalid NOOP response:", scanner.Text())
+	}
+
+	if len(be.messages) != 0 || len(be.anonmsgs) != 0 {
+		t.Fatal("Invalid number of sent messages:", be.messages, be.anonmsgs)
+	}
+}
+
 func TestServer_LMTP_Early(t *testing.T) {
 	// This test confirms responses are sent as early as possible
 	// e.g. right after SetStatus is called.


### PR DESCRIPTION
An LMTP server with `MaxMessageBytes` set stops reading the message at the limit and never picks up the rest. The command loop then carries on from wherever the reader stopped, and answers what's left of the body as commands.

With `MaxMessageBytes = 50` and a body whose third line happens to read `MAIL FROM:<root@example.org>`, a single `DATA` gets four replies:

```
552 5.3.4 <root@gchq.gov.uk> Maximum message size exceeded
500 5.5.2 Syntax errors,  CAN command unrecognized
250 2.0.0 Roger, accepting mail from <root@example.org>
501 5.5.2 Bad command
```

`CAN` is the tail of teh line the reader was cut off in the middle of, and the `501` is the terminating dot. From there on the client is three replies behind.

Plain `DATA` doesn't do this beacuse it drops the limit first. The LMTP handler has the same "make sure all the data has been consumed" copy in both of its branches, and neither one got the accompanying line.

Only bites with `MaxMessageBytes` non-zero. I've run it against this repo's test backend rather than a real delivery agent, so I dont know how one of those copes when its replies are out of step.
